### PR TITLE
Track LLM token usage in a state variable

### DIFF
--- a/soc_agent/agent.py
+++ b/soc_agent/agent.py
@@ -38,13 +38,13 @@ from pathlib import Path
 import vertexai
 from dotenv import load_dotenv
 from google.adk.agents import Agent
+from google.adk.agents.callback_context import CallbackContext
+from google.adk.models import LlmResponse
 from google.adk.tools.mcp_tool.mcp_session_manager import StdioConnectionParams
 from google.adk.tools.mcp_tool.mcp_toolset import McpToolset
 from google.adk.tools.retrieval.vertex_ai_rag_retrieval import VertexAiRagRetrieval
 from mcp import StdioServerParameters
 from vertexai.preview import rag
-from google.adk.agents.callback_context import CallbackContext
-from google.adk.models import LlmResponse
 
 
 # Configure logging
@@ -58,7 +58,9 @@ def track_token_usage(ctx: CallbackContext, response: LlmResponse) -> None:
         total_tokens_used = ctx.state.get("total_tokens_used", 0)
         prompt_tokens = response.usage_metadata.prompt_token_count or 0
         candidates_tokens = response.usage_metadata.candidates_token_count or 0
-        ctx.state["total_tokens_used"] = total_tokens_used + prompt_tokens + candidates_tokens
+        ctx.state["total_tokens_used"] = (
+            total_tokens_used + prompt_tokens + candidates_tokens
+        )
 
 
 def create_agent():

--- a/soc_agent/agent.py
+++ b/soc_agent/agent.py
@@ -43,11 +43,22 @@ from google.adk.tools.mcp_tool.mcp_toolset import McpToolset
 from google.adk.tools.retrieval.vertex_ai_rag_retrieval import VertexAiRagRetrieval
 from mcp import StdioServerParameters
 from vertexai.preview import rag
+from google.adk.agents.callback_context import CallbackContext
+from google.adk.models import LlmResponse
 
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+
+def track_token_usage(ctx: CallbackContext, response: LlmResponse) -> None:
+    """Tracks LLM token usage in a state variable."""
+    if response and response.usage_metadata:
+        total_tokens_used = ctx.state.get("total_tokens_used", 0)
+        prompt_tokens = response.usage_metadata.prompt_token_count or 0
+        candidates_tokens = response.usage_metadata.candidates_token_count or 0
+        ctx.state["total_tokens_used"] = total_tokens_used + prompt_tokens + candidates_tokens
 
 
 def create_agent():
@@ -293,6 +304,7 @@ KEY TOOLS:
 
 Always provide actionable guidance combining documented procedures with live security data.""",
         tools=tools,
+        after_model_callback=[track_token_usage],
     )
 
     logger.info("SOC Agent created successfully!")

--- a/soc_agent_cti/agent.py
+++ b/soc_agent_cti/agent.py
@@ -44,11 +44,22 @@ from google.adk.tools.mcp_tool.mcp_toolset import McpToolset
 from google.adk.tools.retrieval.vertex_ai_rag_retrieval import VertexAiRagRetrieval
 from mcp import StdioServerParameters
 from vertexai.preview import rag
+from google.adk.agents.callback_context import CallbackContext
+from google.adk.models import LlmResponse
 
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+
+def track_token_usage(ctx: CallbackContext, response: LlmResponse) -> None:
+    """Tracks LLM token usage in a state variable."""
+    if response and response.usage_metadata:
+        total_tokens_used = ctx.state.get("total_tokens_used", 0)
+        prompt_tokens = response.usage_metadata.prompt_token_count or 0
+        candidates_tokens = response.usage_metadata.candidates_token_count or 0
+        ctx.state["total_tokens_used"] = total_tokens_used + prompt_tokens + candidates_tokens
 
 # ========================================================================
 # CTI Researcher Persona Definition
@@ -459,6 +470,7 @@ IMPORTANT GUIDELINES:
 
 When researching threats, ALWAYS retrieve relevant runbooks first for structured methodologies. Your RAG corpus contains proven threat research workflows and analytical techniques.""",
         tools=tools,
+        after_model_callback=[track_token_usage],
     )
 
     logger.info("CTI Agent created successfully!")

--- a/soc_agent_cti/agent.py
+++ b/soc_agent_cti/agent.py
@@ -38,14 +38,14 @@ from pathlib import Path
 import vertexai
 from dotenv import load_dotenv
 from google.adk.agents import Agent
+from google.adk.agents.callback_context import CallbackContext
+from google.adk.models import LlmResponse
 from google.adk.tools import AgentTool, google_search
 from google.adk.tools.mcp_tool.mcp_session_manager import StdioConnectionParams
 from google.adk.tools.mcp_tool.mcp_toolset import McpToolset
 from google.adk.tools.retrieval.vertex_ai_rag_retrieval import VertexAiRagRetrieval
 from mcp import StdioServerParameters
 from vertexai.preview import rag
-from google.adk.agents.callback_context import CallbackContext
-from google.adk.models import LlmResponse
 
 
 # Configure logging
@@ -59,7 +59,10 @@ def track_token_usage(ctx: CallbackContext, response: LlmResponse) -> None:
         total_tokens_used = ctx.state.get("total_tokens_used", 0)
         prompt_tokens = response.usage_metadata.prompt_token_count or 0
         candidates_tokens = response.usage_metadata.candidates_token_count or 0
-        ctx.state["total_tokens_used"] = total_tokens_used + prompt_tokens + candidates_tokens
+        ctx.state["total_tokens_used"] = (
+            total_tokens_used + prompt_tokens + candidates_tokens
+        )
+
 
 # ========================================================================
 # CTI Researcher Persona Definition

--- a/soc_agent_flash/agent.py
+++ b/soc_agent_flash/agent.py
@@ -44,11 +44,22 @@ from google.adk.tools.mcp_tool.mcp_toolset import McpToolset
 from google.adk.tools.retrieval.vertex_ai_rag_retrieval import VertexAiRagRetrieval
 from mcp import StdioServerParameters
 from vertexai.preview import rag
+from google.adk.agents.callback_context import CallbackContext
+from google.adk.models import LlmResponse
 
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+
+def track_token_usage(ctx: CallbackContext, response: LlmResponse) -> None:
+    """Tracks LLM token usage in a state variable."""
+    if response and response.usage_metadata:
+        total_tokens_used = ctx.state.get("total_tokens_used", 0)
+        prompt_tokens = response.usage_metadata.prompt_token_count or 0
+        candidates_tokens = response.usage_metadata.candidates_token_count or 0
+        ctx.state["total_tokens_used"] = total_tokens_used + prompt_tokens + candidates_tokens
 
 
 def create_agent():
@@ -299,6 +310,7 @@ KEY TOOLS:
 
 Always provide actionable guidance combining documented procedures with live security data.""",
         tools=tools,
+        after_model_callback=[track_token_usage],
     )
 
     logger.info("SOC Agent created successfully!")

--- a/soc_agent_flash/agent.py
+++ b/soc_agent_flash/agent.py
@@ -38,14 +38,14 @@ from pathlib import Path
 import vertexai
 from dotenv import load_dotenv
 from google.adk.agents import Agent
+from google.adk.agents.callback_context import CallbackContext
+from google.adk.models import LlmResponse
 from google.adk.tools import AgentTool, google_search
 from google.adk.tools.mcp_tool.mcp_session_manager import StdioConnectionParams
 from google.adk.tools.mcp_tool.mcp_toolset import McpToolset
 from google.adk.tools.retrieval.vertex_ai_rag_retrieval import VertexAiRagRetrieval
 from mcp import StdioServerParameters
 from vertexai.preview import rag
-from google.adk.agents.callback_context import CallbackContext
-from google.adk.models import LlmResponse
 
 
 # Configure logging
@@ -59,7 +59,9 @@ def track_token_usage(ctx: CallbackContext, response: LlmResponse) -> None:
         total_tokens_used = ctx.state.get("total_tokens_used", 0)
         prompt_tokens = response.usage_metadata.prompt_token_count or 0
         candidates_tokens = response.usage_metadata.candidates_token_count or 0
-        ctx.state["total_tokens_used"] = total_tokens_used + prompt_tokens + candidates_tokens
+        ctx.state["total_tokens_used"] = (
+            total_tokens_used + prompt_tokens + candidates_tokens
+        )
 
 
 def create_agent():

--- a/soc_agent_tier1/agent.py
+++ b/soc_agent_tier1/agent.py
@@ -38,14 +38,14 @@ from pathlib import Path
 import vertexai
 from dotenv import load_dotenv
 from google.adk.agents import Agent
+from google.adk.agents.callback_context import CallbackContext
+from google.adk.models import LlmResponse
 from google.adk.tools import AgentTool, google_search
 from google.adk.tools.mcp_tool.mcp_session_manager import StdioConnectionParams
 from google.adk.tools.mcp_tool.mcp_toolset import McpToolset
 from google.adk.tools.retrieval.vertex_ai_rag_retrieval import VertexAiRagRetrieval
 from mcp import StdioServerParameters
 from vertexai.preview import rag
-from google.adk.agents.callback_context import CallbackContext
-from google.adk.models import LlmResponse
 
 
 # Configure logging
@@ -59,7 +59,10 @@ def track_token_usage(ctx: CallbackContext, response: LlmResponse) -> None:
         total_tokens_used = ctx.state.get("total_tokens_used", 0)
         prompt_tokens = response.usage_metadata.prompt_token_count or 0
         candidates_tokens = response.usage_metadata.candidates_token_count or 0
-        ctx.state["total_tokens_used"] = total_tokens_used + prompt_tokens + candidates_tokens
+        ctx.state["total_tokens_used"] = (
+            total_tokens_used + prompt_tokens + candidates_tokens
+        )
+
 
 # ========================================================================
 # Tier 1 SOC Analyst Persona Definition

--- a/soc_agent_tier1/agent.py
+++ b/soc_agent_tier1/agent.py
@@ -44,11 +44,22 @@ from google.adk.tools.mcp_tool.mcp_toolset import McpToolset
 from google.adk.tools.retrieval.vertex_ai_rag_retrieval import VertexAiRagRetrieval
 from mcp import StdioServerParameters
 from vertexai.preview import rag
+from google.adk.agents.callback_context import CallbackContext
+from google.adk.models import LlmResponse
 
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+
+def track_token_usage(ctx: CallbackContext, response: LlmResponse) -> None:
+    """Tracks LLM token usage in a state variable."""
+    if response and response.usage_metadata:
+        total_tokens_used = ctx.state.get("total_tokens_used", 0)
+        prompt_tokens = response.usage_metadata.prompt_token_count or 0
+        candidates_tokens = response.usage_metadata.candidates_token_count or 0
+        ctx.state["total_tokens_used"] = total_tokens_used + prompt_tokens + candidates_tokens
 
 # ========================================================================
 # Tier 1 SOC Analyst Persona Definition
@@ -404,6 +415,7 @@ IMPORTANT LIMITATIONS:
 
 When unsure about procedures, ALWAYS retrieve the relevant runbook first. Your RAG corpus contains detailed step-by-step procedures optimized for Tier 1 operations.""",
         tools=tools,
+        after_model_callback=[track_token_usage],
     )
 
     logger.info("SOC Agent created successfully!")


### PR DESCRIPTION
Adds a new `track_token_usage` callback and attaches it to the `after_model_callback` parameter of all `Agent` instantiations in the project (`soc_agent`, `soc_agent_tier1`, `soc_agent_flash`, `soc_agent_cti`). This callback retrieves `prompt_token_count` and `candidates_token_count` from `response.usage_metadata` and safely increments a `total_tokens_used` state variable accessible via `ctx.state`, avoiding potential errors with default fallback values.

---
*PR created automatically by Jules for task [17299861263908569466](https://jules.google.com/task/17299861263908569466) started by @dandye*