### PR TITLE
docs: embed youtube video in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 Deploy security-focused AI agents to Google Cloud with integrated access to Chronicle, SOAR, Threat Intelligence, and Security Command Center through the Model Context Protocol (MCP).
 
+[![Watch the video](https://img.youtube.com/vi/KB2dJQEpjsw/maxresdefault.jpg)](https://www.youtube.com/watch?v=KB2dJQEpjsw)
+
 ## Table of Contents
 
 - [Quick Start](#quick-start)


### PR DESCRIPTION
Added a linked image to a YouTube video in the README.md file using
the Markdown image link syntax with the video's thumbnail image.

---
*PR created automatically by Jules for task [9963241944082830823](https://jules.google.com/task/9963241944082830823) started by @dandye*