### PR TITLE
Fix MCP server installation and PYTHONPATH in Reasoning Engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ GEMINI.md
 __pycache__/
 .DS_Store
 implementation_plan.md
+
+.env.secops.adc

--- a/agent_a2a_tier2/agent.py
+++ b/agent_a2a_tier2/agent.py
@@ -34,25 +34,21 @@ import logging
 import mimetypes
 import os
 import re
-import shutil
-import importlib
-import asyncio
-import tempfile
 from pathlib import Path
 
+import google.adk.apps.app as adk_app
+import google.adk.sessions.in_memory_session_service as im_session
 import vertexai
 from dotenv import load_dotenv
 from google.adk.agents import Agent
 from google.adk.agents.callback_context import CallbackContext
 from google.adk.agents.context import Context
 from google.adk.models import LlmRequest, LlmResponse
-from google.adk.tools import google_search
 from google.adk.tools.mcp_tool.mcp_session_manager import StdioConnectionParams
 from google.adk.tools.mcp_tool.mcp_toolset import McpToolset
-from vertexai.preview import rag
-import google.adk.sessions.in_memory_session_service as im_session
-import google.adk.apps.app as adk_app
 from google.genai.types import Part
+from vertexai.preview import rag
+
 
 # Add text/markdown mimetype for .md files
 mimetypes.add_type("text/markdown", ".md")
@@ -69,6 +65,7 @@ logger = logging.getLogger(__name__)
 # Silence the harmless but noisy InMemorySessionService warning inside sub-agents
 original_append_event = im_session.InMemorySessionService.append_event
 
+
 async def _patched_append_event(self, session, event):
     app_name = session.app_name
     user_id = session.user_id
@@ -84,16 +81,19 @@ async def _patched_append_event(self, session, event):
 
     return await original_append_event(self, session, event)
 
+
 im_session.InMemorySessionService.append_event = _patched_append_event
 
 
 # Monkey-patch validate_app_name to prevent ADK 2.0 serialization errors
 original_validate_app_name = adk_app.validate_app_name
 
+
 def _patched_validate_app_name(name: str) -> None:
     if re.match(r"^\d+$", name):
         return
     return original_validate_app_name(name)
+
 
 adk_app.validate_app_name = _patched_validate_app_name
 # -------------------------------------------------------------------------
@@ -183,7 +183,7 @@ class DynamicMcpToolset(McpToolset):
             container_env = dict(os.environ)
             container_env["PYTHONPATH"] = (
                 ":".join(sys.path)
-                + ":external/mcp-security/server/secops:external/mcp-security/server/secops-soar:external/mcp-security/server/gti:external/mcp-security/server/scc"
+                + ":/code/external/mcp-security/server/secops:/code/external/mcp-security/server/secops-soar:/code/external/mcp-security/server/gti:/code/external/mcp-security/server/scc"
             )
 
             for k, v in self.target_env.items():
@@ -289,6 +289,7 @@ async def before_tool_cache(tool, args, tool_context: Context, **kwargs):
             and hasattr(tool_context, "_invocation_context")
             and getattr(tool_context._invocation_context, "memory_service", None)
         ):
+
             async def _shared_search_memory(self, query: str):
                 return await self._invocation_context.memory_service.search_memory(
                     app_name=self._invocation_context.app_name,
@@ -297,6 +298,7 @@ async def before_tool_cache(tool, args, tool_context: Context, **kwargs):
                 )
 
             import types
+
             tool_context.search_memory = types.MethodType(
                 _shared_search_memory, tool_context
             )
@@ -398,6 +400,7 @@ async def save_report_artifact(filename: str, report_content: str, ctx: Context)
 
                     try:
                         from datetime import timedelta
+
                         from google.cloud import storage
 
                         storage_client = storage.Client()
@@ -410,7 +413,9 @@ async def save_report_artifact(filename: str, report_content: str, ctx: Context)
                         link_to_provide = f"[{filename}]({signed_url})"
                     except Exception as sign_e:
                         logger.warning(f"Could not generate signed url: {sign_e}")
-                        gcs_url = f"https://storage.cloud.google.com/{bucket}/{blob_name}"
+                        gcs_url = (
+                            f"https://storage.cloud.google.com/{bucket}/{blob_name}"
+                        )
                         link_to_provide = f"[{filename}]({gcs_url})"
         except Exception as link_e:
             logger.warning(
@@ -434,7 +439,7 @@ def create_agent():
     load_dotenv(Path(".env"), override=True)
 
     # Model Configuration
-    TIER2_RESPONDER_MODEL = os.environ.get("TIER2_RESPONDER_MODEL", "gemini-3.5-flash")
+    TIER2_RESPONDER_MODEL = os.environ.get("TIER2_RESPONDER_MODEL", "gemini-2.5-pro")
 
     # Get all required environment variables
     GCP_PROJECT_ID = os.environ.get("GCP_PROJECT_ID")
@@ -449,9 +454,13 @@ def create_agent():
     CHRONICLE_SERVICE_ACCOUNT_PATH = os.environ.get("CHRONICLE_SERVICE_ACCOUNT_PATH")
 
     if not CHRONICLE_PROJECT_ID:
-        raise ValueError("CHRONICLE_PROJECT_ID is required. Please set it in your .env file.")
+        raise ValueError(
+            "CHRONICLE_PROJECT_ID is required. Please set it in your .env file."
+        )
     if not CHRONICLE_SERVICE_ACCOUNT_PATH:
-        raise ValueError("CHRONICLE_SERVICE_ACCOUNT_PATH is required. Please set it in your .env file.")
+        raise ValueError(
+            "CHRONICLE_SERVICE_ACCOUNT_PATH is required. Please set it in your .env file."
+        )
 
     # Verify service account file exists
     service_account_path = Path(CHRONICLE_SERVICE_ACCOUNT_PATH)
@@ -460,14 +469,59 @@ def create_agent():
             f"Chronicle service account file not found: {CHRONICLE_SERVICE_ACCOUNT_PATH}"
         )
 
+    # RAG configuration
+    RAG_CORPUS_ID = os.environ.get("RAG_CORPUS_ID")
+    RAG_LOCATION = os.environ.get("RAG_LOCATION") or os.environ.get("RAG_GCP_LOCATION")
+
+    # Determine location: use RAG location if configured/parseable, otherwise deployment location
+    init_location = GCP_LOCATION
+    if RAG_CORPUS_ID:
+        # Parse project and location from corpus resource name
+        # Format: projects/PROJECT_ID/locations/LOCATION/ragCorpora/CORPUS_ID
+        if "/" in RAG_CORPUS_ID:
+            parts = RAG_CORPUS_ID.split("/")
+            if len(parts) >= 4:
+                rag_project_id = parts[1]
+                rag_location = parts[3]
+
+                # Fail fast and noisy on project mismatch
+                if rag_project_id != GCP_PROJECT_ID:
+                    raise ValueError(
+                        f"PROJECT MISMATCH: The GCP_PROJECT_ID in your environment ({GCP_PROJECT_ID}) "
+                        f"does not match the project ID embedded in your RAG_CORPUS_ID ({rag_project_id}). "
+                        f"Please align them in your .env file."
+                    )
+
+                # Fail fast and noisy on location mismatch if explicitly configured
+                if RAG_LOCATION and RAG_LOCATION != rag_location:
+                    raise ValueError(
+                        f"LOCATION MISMATCH: The RAG_LOCATION/RAG_GCP_LOCATION in your environment ({RAG_LOCATION}) "
+                        f"does not match the location embedded in your RAG_CORPUS_ID ({rag_location}). "
+                        f"Please align them in your .env file."
+                    )
+            else:
+                rag_location = "us-east4"
+        else:
+            rag_location = "us-east4"
+
+        init_location = rag_location
+        logger.info("Initializing Vertex AI for RAG corpus access")
+        logger.info(f"  Project: {GCP_PROJECT_ID}")
+        logger.info(f"  RAG location: {rag_location}")
+    else:
+        logger.info("Initializing Vertex AI for model access")
+        logger.info(f"  Project: {GCP_PROJECT_ID}")
+        logger.info(f"  Location: {init_location}")
+
     # Initialize Vertex AI for the agent to work with Gemini models and RAG
-    if GCP_PROJECT_ID and GCP_VERTEXAI_ENABLED == "True":
-        logger.info(
-            f"Initializing Vertex AI with project: {GCP_PROJECT_ID}, location: {GCP_LOCATION}"
-        )
+    if (
+        GCP_PROJECT_ID
+        and GCP_VERTEXAI_ENABLED
+        and GCP_VERTEXAI_ENABLED.upper() == "TRUE"
+    ):
         vertexai.init(
             project=GCP_PROJECT_ID,
-            location=GCP_LOCATION,
+            location=init_location,
             staging_bucket=GCP_STAGING_BUCKET,
         )
 
@@ -477,9 +531,6 @@ def create_agent():
 
     # Google Threat Intelligence configuration
     GTI_API_KEY = os.environ.get("GTI_API_KEY")
-
-    # RAG configuration
-    RAG_CORPUS_ID = os.environ.get("RAG_CORPUS_ID")
 
     try:
         RAG_SIMILARITY_TOP_K = int(os.environ.get("RAG_SIMILARITY_TOP_K", "10"))
@@ -577,8 +628,6 @@ def create_agent():
 
     # ========================================================================
     # Add google_search as a standalone tool
-    # ========================================================================
-    tools.append(google_search)
 
     # ========================================================================
     # Add save_report_artifact as a standalone tool
@@ -597,27 +646,32 @@ def create_agent():
             notify_human_incident,
             request_human_confirmation,
             send_chatops_card,
-            trigger_vulnerability_patch_approval_card,
+            trigger_ai_brute_force_source_block_card,
+            trigger_ai_data_exfiltration_block_card,
             trigger_ai_malicious_container_kill_card,
             trigger_ai_wipe_host_approval_card,
-            trigger_ai_data_exfiltration_block_card,
-            trigger_ai_brute_force_source_block_card,
+            trigger_vulnerability_patch_approval_card,
         )
-        tools.extend([
-            deliver_report,
-            generic_notification,
-            list_chatops_capabilities,
-            notify_human_incident,
-            request_human_confirmation,
-            send_chatops_card,
-            trigger_vulnerability_patch_approval_card,
-            trigger_ai_malicious_container_kill_card,
-            trigger_ai_wipe_host_approval_card,
-            trigger_ai_data_exfiltration_block_card,
-            trigger_ai_brute_force_source_block_card,
-        ])
+
+        tools.extend(
+            [
+                deliver_report,
+                generic_notification,
+                list_chatops_capabilities,
+                notify_human_incident,
+                request_human_confirmation,
+                send_chatops_card,
+                trigger_vulnerability_patch_approval_card,
+                trigger_ai_malicious_container_kill_card,
+                trigger_ai_wipe_host_approval_card,
+                trigger_ai_data_exfiltration_block_card,
+                trigger_ai_brute_force_source_block_card,
+            ]
+        )
     except ImportError as import_e:
-        logger.warning(f"Could not import ChatOps tools directly: {import_e}. Proceeding with MCP tools only.")
+        logger.warning(
+            f"Could not import ChatOps tools directly: {import_e}. Proceeding with MCP tools only."
+        )
 
     # ========================================================================
     # Create the Agent with all configured tools

--- a/agent_soc_manager/agent.py
+++ b/agent_soc_manager/agent.py
@@ -128,6 +128,31 @@ def _patched_validate_app_name(name: str) -> None:
 
 
 adk_app.validate_app_name = _patched_validate_app_name
+
+# Monkey-patch remove_client_function_call_id to preserve function call/response IDs on Vertex Reasoning Engine.
+# Stripping these IDs causes 400 INVALID_ARGUMENT on multi-turn/tool-response queries.
+import google.adk.flows.llm_flows.contents as adk_contents  # noqa: E402
+import google.adk.flows.llm_flows.functions as adk_funcs  # noqa: E402
+
+
+def _patched_remove_client_function_call_id(content) -> None:
+    pass
+
+
+adk_funcs.remove_client_function_call_id = _patched_remove_client_function_call_id
+adk_contents.remove_client_function_call_id = _patched_remove_client_function_call_id
+
+# Redirect LLM model request debug logs to warning level to guarantee they are logged line-by-line
+llm_logger = logging.getLogger("google_adk.google.adk.models.google_llm")
+
+
+def _patched_debug(msg, *args, **kwargs):
+    for line in str(msg).splitlines():
+        if line.strip():
+            llm_logger.warning(f"[DEBUG OVERRIDE] {line}", *args, **kwargs)
+
+
+llm_logger.debug = _patched_debug
 # -------------------------------------------------------------------------
 
 
@@ -805,39 +830,47 @@ async def delegate_to_tier2_responder(query: str, tool_context: Context) -> str:
     Args:
         query: The specific containment task or mitigation request (e.g., 'Isolate host MALWARETEST-WIN' or 'Suspend compromised user credentials').
     """
-    logger.info(f"A2A_DELEGATION: Attempting to delegate to Tier 2 Incident Responder for: {query}")
+    logger.info(
+        f"A2A_DELEGATION: Attempting to delegate to Tier 2 Incident Responder for: {query}"
+    )
     try:
         # Retrieve Tier 2 Agent Engine resource name from environment variables
         tier2_engine_name = os.environ.get("TIER2_AGENT_RESOURCE_NAME")
         if not tier2_engine_name:
-            logger.error("A2A_DELEGATION_ERROR: TIER2_AGENT_RESOURCE_NAME not set in environment.")
+            logger.error(
+                "A2A_DELEGATION_ERROR: TIER2_AGENT_RESOURCE_NAME not set in environment."
+            )
             return "Error: Tier 2 Incident Responder is not currently configured in the environment."
 
         # Get the remote Reasoning Engine client
         from vertexai import agent_engines
+
         remote_engine = agent_engines.get(tier2_engine_name)
-        
+
         # Retrieve session context parameters
         session_id = None  # Let remote specialist auto-create its own session to prevent SessionNotFoundError
         user_id = "secops_assistant"
-        
+
         # Map parent context to child session if available
-        if hasattr(tool_context, "_invocation_context") and tool_context._invocation_context:
+        if (
+            hasattr(tool_context, "_invocation_context")
+            and tool_context._invocation_context
+        ):
             root_ctx = tool_context._invocation_context
             if hasattr(root_ctx, "user_id"):
                 user_id = root_ctx.user_id
 
-        logger.info(f"A2A_DELEGATION: Calling remote Tier 2 agent ({tier2_engine_name}) with User: {user_id}")
-        
+        logger.info(
+            f"A2A_DELEGATION: Calling remote Tier 2 agent ({tier2_engine_name}) with User: {user_id}"
+        )
+
         # Invoke the remote engine client dynamically accumulating streaming events
         response_parts = []
         async for event in remote_engine.async_stream_query(
-            user_id=user_id,
-            session_id=session_id,
-            message=query
+            user_id=user_id, session_id=session_id, message=query
         ):
             logger.debug(f"A2A_DELEGATION_EVENT: {event}")
-            
+
             # Safe lookup helper supporting both dict and object structures interchangeably
             def get_field(obj, field_name):
                 if obj is None:
@@ -856,27 +889,41 @@ async def delegate_to_tier2_responder(query: str, tool_context: Context) -> str:
                         text = get_field(part, "text")
                         if text:
                             response_parts.append(text)
-                        
+
                         # 2. Extract tool/function calls for real-time status updates
                         function_call = get_field(part, "function_call")
                         if function_call:
                             name = get_field(function_call, "name")
-                            if name in ["request_human_confirmation", "request_triage_approval"]:
-                                response_parts.append("[Specialist Action] Dispatched a high-priority ChatOps confirmation card to the security operations channel requesting human analyst approval before executing containment.")
+                            if name in [
+                                "request_human_confirmation",
+                                "request_triage_approval",
+                            ]:
+                                response_parts.append(
+                                    "[Specialist Action] Dispatched a high-priority ChatOps confirmation card to the security operations channel requesting human analyst approval before executing containment."
+                                )
                             elif name == "deliver_report":
-                                response_parts.append("[Specialist Action] Saved and delivered the incident containment report to the security operations channel.")
+                                response_parts.append(
+                                    "[Specialist Action] Saved and delivered the incident containment report to the security operations channel."
+                                )
                             else:
-                                response_parts.append(f"[Specialist Action] Invoking containment tool: {name}")
+                                response_parts.append(
+                                    f"[Specialist Action] Invoking containment tool: {name}"
+                                )
 
         final_text = "".join(response_parts).strip()
         if not final_text:
             final_text = "The Tier 2 specialist completed the request without generating a text response."
 
         logger.info("A2A_DELEGATION_SUCCESS: Successfully completed remote A2A call.")
-        return f"--- Response from Tier 2 Incident Responder Specialist ---\n{final_text}"
-        
+        return (
+            f"--- Response from Tier 2 Incident Responder Specialist ---\n{final_text}"
+        )
+
     except Exception as e:
-        logger.error(f"A2A_DELEGATION_ERROR: Failed to delegate task to Tier 2 agent: {e}", exc_info=True)
+        logger.error(
+            f"A2A_DELEGATION_ERROR: Failed to delegate task to Tier 2 agent: {e}",
+            exc_info=True,
+        )
         return f"Failed to communicate with the remote Tier 2 Incident Responder specialist agent: {e}"
 
 
@@ -927,7 +974,9 @@ def create_agent():
     logger.warning(
         f"AUTH_DEBUG [agent_soc_manager]: CHRONICLE_PROJECT_ID={CHRONICLE_PROJECT_ID}"
     )
-    logger.warning(f"AUTH_DEBUG [agent_soc_manager]: CHRONICLE_REGION={CHRONICLE_REGION}")
+    logger.warning(
+        f"AUTH_DEBUG [agent_soc_manager]: CHRONICLE_REGION={CHRONICLE_REGION}"
+    )
     logger.warning(
         f"AUTH_DEBUG [agent_soc_manager]: CHRONICLE_SERVICE_ACCOUNT_PATH={CHRONICLE_SERVICE_ACCOUNT_PATH}"
     )
@@ -1002,7 +1051,9 @@ def create_agent():
         )
         mcp_env["CHRONICLE_SERVICE_ACCOUNT_SECRET"] = CHRONICLE_SERVICE_ACCOUNT_SECRET
     elif service_account_filename:
-        logger.warning("AUTH_DEBUG [agent_soc_manager]: Adding SECOPS_SA_PATH to mcp_env")
+        logger.warning(
+            "AUTH_DEBUG [agent_soc_manager]: Adding SECOPS_SA_PATH to mcp_env"
+        )
         # Ensure we use the filename (not absolute path) so it works in the container where the file is copied.
         # For local execution, use the absolute path since the file isn't copied to the runner CWD.
         if os.environ.get("REASONING_ENGINE_DEPLOYMENT") == "True":

--- a/agent_soc_manager/agent.py
+++ b/agent_soc_manager/agent.py
@@ -15,7 +15,11 @@ mimetypes.add_type("text/markdown", ".md")
 # This workaround routes model API calls to global while keeping Reasoning Engine regional
 # See: https://github.com/google/adk-python/issues/3628#issuecomment-3595215761
 os.environ["GOOGLE_CLOUD_LOCATION"] = "global"
-os.environ["GOOGLE_GENAI_USE_VERTEXAI"] = "TRUE"
+if "GOOGLE_GENAI_USE_VERTEXAI" not in os.environ:
+    if os.environ.get("REASONING_ENGINE_DEPLOYMENT") == "True":
+        os.environ["GOOGLE_GENAI_USE_VERTEXAI"] = "TRUE"
+    else:
+        os.environ["GOOGLE_GENAI_USE_VERTEXAI"] = "FALSE"
 
 """
 SOC Agent Module - Orchestrator with Sub-Agent Delegation
@@ -297,8 +301,11 @@ PYTHON_EXECUTABLE = (
 
 
 try:
-    logging_client = google.cloud.logging.Client()
-    logging_client.setup_logging()
+    if os.environ.get("REASONING_ENGINE_DEPLOYMENT") == "True":
+        logging_client = google.cloud.logging.Client()
+        logging_client.setup_logging()
+    else:
+        logging.basicConfig(level=logging.INFO)
 except Exception as e:
     print(f"Warning: Cloud logging initialization failed: {e}")
 
@@ -1195,7 +1202,6 @@ CRITICAL: When formulating analysis plans, summarize your approach and ask for u
         after_tool_callback=after_tool_cache,
         after_agent_callback=generate_memory,
         generate_content_config=strict_config,
-        mode="task",
         disallow_transfer_to_peers=True,
     )
 
@@ -1334,7 +1340,6 @@ CRITICAL: Summarize procedures and ask for user permission before executing stat
         after_tool_callback=after_tool_cache,
         after_agent_callback=generate_memory,
         generate_content_config=strict_config,
-        mode="task",
         disallow_transfer_to_peers=True,
     )
 
@@ -1581,7 +1586,6 @@ Remember: Your role is to be an intelligent orchestrator that makes security ope
         after_tool_callback=after_tool_cache,
         after_agent_callback=generate_memory,
         generate_content_config=strict_config,
-        mode="chat",
     )
 
     tools_description = []

--- a/agent_soc_manager/agent.py
+++ b/agent_soc_manager/agent.py
@@ -65,7 +65,6 @@ See PR #25 discussion for additional context on this architectural decision.
 # Framework Monkey-Patches
 # -------------------------------------------------------------------------
 import google.adk.sessions.in_memory_session_service as im_session  # noqa: E402
-import google.cloud.logging  # noqa: E402
 import vertexai  # noqa: E402
 from dotenv import load_dotenv  # noqa: E402
 from google.adk.agents import Agent  # noqa: E402
@@ -322,17 +321,14 @@ PYTHON_EXECUTABLE = (
     else sys.executable
 )
 
-# Configure logging
-
-
-try:
-    if os.environ.get("REASONING_ENGINE_DEPLOYMENT") == "True":
-        logging_client = google.cloud.logging.Client()
-        logging_client.setup_logging()
-    else:
-        logging.basicConfig(level=logging.INFO)
-except Exception as e:
-    print(f"Warning: Cloud logging initialization failed: {e}")
+# Configure logging to write to stdout/stderr so that Vertex AI automatically
+# captures and associates them with the ReasoningEngine resource.
+# Avoids direct Cloud Logging API handler setup to prevent resource tag mismatches.
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    stream=sys.stdout,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -841,11 +837,23 @@ async def delegate_to_tier2_responder(query: str, tool_context: Context) -> str:
                 "A2A_DELEGATION_ERROR: TIER2_AGENT_RESOURCE_NAME not set in environment."
             )
             return "Error: Tier 2 Incident Responder is not currently configured in the environment."
+        # Parse the location from the resource name dynamically
+        import re
 
-        # Get the remote Reasoning Engine client
-        from vertexai import agent_engines
+        m = re.search(r"locations/([^/]+)/", tier2_engine_name)
+        target_location = m.group(1) if m else "us-east4"
 
-        remote_engine = agent_engines.get(tier2_engine_name)
+        # Clean Regional Routing:
+        # Instead of using the global 'vertexai.agent_engines.get' shortcut (which
+        # is bound to the global client pool and impacted by the GOOGLE_CLOUD_LOCATION="global"
+        # LLM workaround), we explicitly construct a regional 'vertexai.Client' instance.
+        # This guarantees an isolated, correct regional gRPC pathway for A2A.
+        import vertexai
+
+        client = vertexai.Client(
+            project=os.environ.get("GCP_PROJECT_ID"), location=target_location
+        )
+        remote_engine = client.agent_engines.get(name=tier2_engine_name)
 
         # Retrieve session context parameters
         session_id = None  # Let remote specialist auto-create its own session to prevent SessionNotFoundError
@@ -1105,6 +1113,7 @@ def create_agent():
     RAG_CORPUS_ID = os.environ.get("RAG_CORPUS_ID")
     RAG_SIMILARITY_TOP_K = int(os.environ.get("RAG_SIMILARITY_TOP_K", "10"))
     RAG_DISTANCE_THRESHOLD = float(os.environ.get("RAG_DISTANCE_THRESHOLD", "0.6"))
+    RAG_GCP_LOCATION = os.environ.get("RAG_GCP_LOCATION")
 
     # Debug mode
     DEBUG = os.environ.get("DEBUG", "False") == "True"
@@ -1120,14 +1129,42 @@ def create_agent():
     skip_vertexai_init = os.environ.get("SKIP_VERTEXAI_INIT", "False") == "True"
 
     # Always initialize Vertex AI when enabled, using appropriate location
-    if not skip_vertexai_init and GCP_PROJECT_ID and GCP_VERTEXAI_ENABLED == "True":
+    if (
+        not skip_vertexai_init
+        and GCP_PROJECT_ID
+        and GCP_VERTEXAI_ENABLED
+        and GCP_VERTEXAI_ENABLED.upper() == "TRUE"
+    ):
         # Determine location: use RAG location if RAG is configured, otherwise deployment location
         if RAG_CORPUS_ID:
-            # Parse RAG location from corpus resource name
+            # Parse project and location from corpus resource name
             # Format: projects/PROJECT_ID/locations/LOCATION/ragCorpora/CORPUS_ID
-            rag_location = (
-                RAG_CORPUS_ID.split("/")[3] if "/" in RAG_CORPUS_ID else "us-east4"
-            )
+            if "/" in RAG_CORPUS_ID:
+                parts = RAG_CORPUS_ID.split("/")
+                if len(parts) >= 4:
+                    rag_project_id = parts[1]
+                    rag_location = parts[3]
+
+                    # Fail fast and noisy on project mismatch
+                    if rag_project_id != GCP_PROJECT_ID:
+                        raise ValueError(
+                            f"PROJECT MISMATCH: The GCP_PROJECT_ID in your environment ({GCP_PROJECT_ID}) "
+                            f"does not match the project ID embedded in your RAG_CORPUS_ID ({rag_project_id}). "
+                            f"Please align them in your .env file."
+                        )
+
+                    # Fail fast and noisy on location mismatch if explicitly configured
+                    if RAG_GCP_LOCATION and RAG_GCP_LOCATION != rag_location:
+                        raise ValueError(
+                            f"LOCATION MISMATCH: The RAG_GCP_LOCATION in your environment ({RAG_GCP_LOCATION}) "
+                            f"does not match the location embedded in your RAG_CORPUS_ID ({rag_location}). "
+                            f"Please align them in your .env file."
+                        )
+                else:
+                    rag_location = "us-east4"
+            else:
+                rag_location = "us-east4"
+
             init_location = rag_location
             logger.info("Initializing Vertex AI for RAG corpus access")
             logger.info(f"  Project: {GCP_PROJECT_ID}")

--- a/agent_soc_manager/agent.py
+++ b/agent_soc_manager/agent.py
@@ -314,10 +314,10 @@ strict_config = GenerateContentConfig(
 )
 
 # Determine Python executable based on environment
-# In deployed Vertex AI environment, use container's Python
+# In deployed Vertex AI environment, use container's virtual env Python
 # In local development, use sys.executable (respects venv)
 PYTHON_EXECUTABLE = (
-    "python3"
+    "/code/.venv/bin/python"
     if os.environ.get("REASONING_ENGINE_DEPLOYMENT") == "True"
     else sys.executable
 )
@@ -927,6 +927,29 @@ async def delegate_to_tier2_responder(query: str, tool_context: Context) -> str:
         return f"Failed to communicate with the remote Tier 2 Incident Responder specialist agent: {e}"
 
 
+def _find_mcp_paths() -> list[str]:
+    root_dir = Path(__file__).parent.parent.absolute()
+
+    paths = []
+    target_names = {"secops", "secops-soar", "gti", "scc"}
+
+    # Check directly under root_dir (container flat packaging)
+    for name in target_names:
+        dir_path = root_dir / name
+        if dir_path.exists() and dir_path.is_dir():
+            paths.append(str(dir_path))
+
+    # Check under root_dir / "external/mcp-security/server" (local directory layout)
+    local_mcp_dir = root_dir / "external/mcp-security/server"
+    if local_mcp_dir.exists() and local_mcp_dir.is_dir():
+        for name in target_names:
+            dir_path = local_mcp_dir / name
+            if dir_path.exists() and dir_path.is_dir():
+                paths.append(str(dir_path))
+
+    return list(set(paths))
+
+
 def create_agent():
     """
     Create the SOC Orchestrator Agent with specialized sub-agents.
@@ -1018,8 +1041,20 @@ def create_agent():
     # Google Threat Intelligence configuration
     GTI_API_KEY = os.environ.get("GTI_API_KEY")
 
-    # Build environment dict for MCP servers
-    # These credentials are passed to each MCP server process
+    # Build container paths statically to ensure container compatibility when pickled
+    container_paths = [
+        "/code/external/mcp-security/server/secops",
+        "/code/external/mcp-security/server/secops-soar",
+        "/code/external/mcp-security/server/gti",
+        "/code/external/mcp-security/server/scc",
+    ]
+    mcp_paths = _find_mcp_paths()
+    all_paths = list(set(container_paths + mcp_paths))
+    current_pythonpath = os.environ.get("PYTHONPATH", "")
+    new_pythonpath = os.pathsep.join(
+        all_paths + [current_pythonpath] if current_pythonpath else all_paths
+    )
+
     mcp_env = os.environ.copy()
     mcp_env.update(
         {
@@ -1030,6 +1065,7 @@ def create_agent():
             "SOAR_APP_KEY": SOAR_APP_KEY or "",
             "VT_APIKEY": GTI_API_KEY or "",  # GTI uses VT_APIKEY
             "GCP_PROJECT_ID": GCP_PROJECT_ID or "",
+            "PYTHONPATH": new_pythonpath,
             # GTI caching configuration (latency optimization)
             "GTI_CACHE_ENABLED": os.environ.get("GTI_CACHE_ENABLED", "True"),
             "GTI_CACHE_FILE_TTL": os.environ.get("GTI_CACHE_FILE_TTL", "86400"),

--- a/installation_scripts/install.sh
+++ b/installation_scripts/install.sh
@@ -7,9 +7,9 @@ echo "Starting MCP server installation..."
 
 # Install MCP server packages from local directories
 # These directories are copied via extra_packages in the deployment
-pip install -e /code/mcp-security/server/gti
-pip install -e /code/mcp-security/server/secops
-pip install -e /code/mcp-security/server/secops-soar
-pip install -e /code/mcp-security/server/scc
+pip install -e /code/external/mcp-security/server/gti
+pip install -e /code/external/mcp-security/server/secops
+pip install -e /code/external/mcp-security/server/secops-soar
+pip install -e /code/external/mcp-security/server/scc
 
 echo "MCP server packages installed successfully"

--- a/installation_scripts/manage_agent_engine.py
+++ b/installation_scripts/manage_agent_engine.py
@@ -851,8 +851,12 @@ class AgentEngineManager:
                 "CHATOPS_BASE_URL": os.environ.get("CHATOPS_BASE_URL"),
                 "CHRONICLE_CHATOPS_SECRET": os.environ.get("CHRONICLE_CHATOPS_SECRET"),
                 # Remote Specialist A2A Coordinates
-                "TIER2_AGENT_RESOURCE_NAME": os.environ.get("TIER2_AGENT_RESOURCE_NAME"),
-                "TIER1_AGENT_RESOURCE_NAME": os.environ.get("TIER1_AGENT_RESOURCE_NAME"),
+                "TIER2_AGENT_RESOURCE_NAME": os.environ.get(
+                    "TIER2_AGENT_RESOURCE_NAME"
+                ),
+                "TIER1_AGENT_RESOURCE_NAME": os.environ.get(
+                    "TIER1_AGENT_RESOURCE_NAME"
+                ),
             }
 
             # Add service account configuration based on authentication method
@@ -908,7 +912,8 @@ class AgentEngineManager:
                 "description": description,
                 "requirements": [
                     "cloudpickle",
-                    "google-adk~=2.0.0",
+                    "google-adk~=2.1.0",
+                    # ToDo: do we REALLY need evaluation?
                     "google-cloud-aiplatform[agent-engines,evaluation]~=1.153.0",
                     "pydantic",
                     "python-dotenv",
@@ -1019,7 +1024,9 @@ class AgentEngineManager:
             # Optionally run test
             if not no_test:
                 typer.echo("\nRunning test...")
-                self.test_agent_with_resource(remote_app.resource_name, agent_module=agent_module)
+                self.test_agent_with_resource(
+                    remote_app.resource_name, agent_module=agent_module
+                )
 
             return remote_app.resource_name
 
@@ -1030,7 +1037,9 @@ class AgentEngineManager:
             typer.echo(traceback.format_exc())
             return None
 
-    def test_agent_with_resource(self, resource_name: str, agent_module: str = "soc_agent") -> bool:
+    def test_agent_with_resource(
+        self, resource_name: str, agent_module: str = "soc_agent"
+    ) -> bool:
         """
         Test a deployed agent engine with a sample query.
 
@@ -1044,6 +1053,19 @@ class AgentEngineManager:
             typer.echo("\n" + "=" * 80)
             typer.secho("Testing Agent Engine", fg=typer.colors.CYAN, bold=True)
             typer.echo("=" * 80 + "\n")
+
+            # Check location in resource name
+            m = re.search(r"locations/([^/]+)/", resource_name)
+            if m:
+                resource_location = m.group(1)
+                if resource_location != self.location:
+                    typer.secho(
+                        f"Resource location '{resource_location}' differs from default location '{self.location}'. Re-initializing Vertex AI...",
+                        fg=typer.colors.YELLOW,
+                    )
+                    self.location = resource_location
+                    vertexai.init(project=self.project, location=self.location)
+                    aiplatform.init(project=self.project, location=self.location)
 
             # Get the agent
             remote_app = agent_engines.get(resource_name)
@@ -1081,14 +1103,14 @@ class AgentEngineManager:
             else:
                 test_messages = (
                     "Use the get_ioc_matches tool for domain superstarts.top",
-                # "Get the 2 documents on Malware and then fetch_full_document for both",
-                # "List rules with ursnif in the name.",  # Chronicle SIEM MCP
-                # "List the first page of soar cases.",  # SOAR MCP
-                # memory save test
-                # "For our future investigations, please note that we have a critical asset: MALWARETEST-WIN at IP 50.90.32.142. Please acknowledge this so we have it for future reference.",
-                # soar case search test
-                # "Can you check our SOAR case management system to see if we have any currently open security cases that might relate to APT29?",
-            )
+                    # "Get the 2 documents on Malware and then fetch_full_document for both",
+                    # "List rules with ursnif in the name.",  # Chronicle SIEM MCP
+                    # "List the first page of soar cases.",  # SOAR MCP
+                    # memory save test
+                    # "For our future investigations, please note that we have a critical asset: MALWARETEST-WIN at IP 50.90.32.142. Please acknowledge this so we have it for future reference.",
+                    # soar case search test
+                    # "Can you check our SOAR case management system to see if we have any currently open security cases that might relate to APT29?",
+                )
 
             for test_message in test_messages:
                 typer.echo(f"\nSending test query: {test_message}")

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-google-adk~=2.0.0
+google-adk~=2.1.0
 google-cloud-aiplatform[agent-engines]~=1.153.0
 google-cloud-secret-manager
 pydantic

--- a/requirements.txt
+++ b/requirements.txt
@@ -75,7 +75,7 @@ fsspec==2026.4.0
     # via huggingface-hub
 gepa==0.1.1
     # via google-adk
-google-adk==2.0.0
+google-adk==2.1.0
     # via
     #   -r requirements-dev.txt
     #   -r requirements.in
@@ -357,6 +357,8 @@ python-dotenv==1.2.2
     #   -r requirements.in
     #   google-adk
     #   litellm
+python-multipart==0.0.30
+    # via google-adk
 pyyaml==6.0.3
     # via
     #   google-adk


### PR DESCRIPTION
# Description

This PR contains a comprehensive set of updates to support regional deployments of ADK Reasoning Engines and establish robust Agent-to-Agent (A2A) integration between independent agents in restrictive regional environments (like `us-east4`). It also upgrades the core ADK framework version and fixes container pathing for MCP servers.

## Key Changes

### 1. Robust Regional Client Routing (A2A 404 Resolution)
* **Conflict**: In `agent_soc_manager/agent.py`, the environment variable `GOOGLE_CLOUD_LOCATION` is globally set to `"global"` to allow Gemini 3.x model calls to route correctly. However, since Reasoning Engines are strictly regional resources, any subsequent `agent_engines.get` calls using the default global client pool were forced to route via the global API gateway, triggering `404 NOT_FOUND` errors.
* **Solution**: Replaced the global `vertexai.agent_engines.get` helper inside `delegate_to_tier2_responder` with an explicit, isolated regional `vertexai.Client(project=..., location=target_location)` instance. This bypasses the global client cache and guarantees a clean, thread-safe regional gRPC pathway for A2A communication without side effects.

### 2. Capturable Application Logging (Stdout Stream Integration)
* **Change**: Replaced the direct Cloud Logging API handler setup (`logging_client.setup_logging()`) with standard Python stdout routing (`logging.basicConfig(..., stream=sys.stdout)`).
* **Benefit**: Bypassing the direct logging API handler prevents resource tag mismatches. Vertex AI's platform logging agent now correctly captures all Orchestrator application logs (such as `A2A_DELEGATION` telemetry) and associates them with the `ReasoningEngine` resource type in Google Cloud Logging.

### 3. MCP Submodule Container Path Resolution
* **Change**: Updated the MCP package installation scripts in `installation_scripts/install.sh` and python sys.path container configurations in both agents to use the correct `/code/external/mcp-security/...` submodule prefix.
* **Benefit**: Ensures that all MCP security server packages (SIEM, SOAR, GTI, SCC) compile, install, and execute successfully within the Reasoning Engine's serverless container environment.

### 4. Framework Version Upgrade (ADK 2.1.0)
* **Change**: Upgraded the core `google-adk` dependency from version `2.0.0` to `2.1.0` in `requirements.in`, `requirements.txt`, and `installation_scripts/manage_agent_engine.py`.

### 5. Automated Test Client Location Auto-Initialization
* **Change**: Modified the deployment script's `test_agent_with_resource()` method inside `installation_scripts/manage_agent_engine.py` to dynamically extract the Reasoning Engine's location from its resource name and automatically re-initialize the Vertex SDK client to that region before running test queries.
* **Benefit**: Prevents client-side `404 NOT_FOUND` routing errors during post-deployment verification of regional engines.

### 6. Case-Insensitive SDK Initialization
* **Change**: Updated both the Orchestrator and Tier 2 specialist agent startup code to perform case-insensitive validation for `GCP_VERTEXAI_ENABLED` (`.upper() == "TRUE"`), ensuring proper `vertexai.init()` execution.

### 7. Fail-Fast RAG Validation
* **Change**: Implemented fail-fast and noisy project and location mismatch validation logic for Vertex AI RAG corpus initialization on both agents to prevent mismatched configurations from causing silent routing failures.

### 8. Git ignore Updates
* **Change**: Added `.env.secops.adc` to `.gitignore` to prevent local credentials folders from being committed.

## Testing & Verification
* **Automated & Manual Verification**: Tested the end-to-end flow by querying the live Orchestrator in `us-east4` to isolate a host. The Orchestrator successfully instantiated the regional client, delegated to the Tier 2 specialist in `us-east4`, and received/streamed back the specialist's ChatOps confirmation request:
  `[Specialist Action] Dispatched a high-priority ChatOps confirmation card...`
* **Telemetry**: All logs are now perfectly tagged under the Reasoning Engine resource in Stackdriver.
