### PR TITLE
Upgrade ADK to 2.2.0, patch session validation, and filter remote schemas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ GEMINI.md
 __pycache__/
 .DS_Store
 implementation_plan.md
+
+.env.secops.adc

--- a/agent_a2a_tier2/agent.py
+++ b/agent_a2a_tier2/agent.py
@@ -34,25 +34,21 @@ import logging
 import mimetypes
 import os
 import re
-import shutil
-import importlib
-import asyncio
-import tempfile
 from pathlib import Path
 
+import google.adk.apps.app as adk_app
+import google.adk.sessions.in_memory_session_service as im_session
 import vertexai
 from dotenv import load_dotenv
 from google.adk.agents import Agent
 from google.adk.agents.callback_context import CallbackContext
 from google.adk.agents.context import Context
 from google.adk.models import LlmRequest, LlmResponse
-from google.adk.tools import google_search
 from google.adk.tools.mcp_tool.mcp_session_manager import StdioConnectionParams
 from google.adk.tools.mcp_tool.mcp_toolset import McpToolset
-from vertexai.preview import rag
-import google.adk.sessions.in_memory_session_service as im_session
-import google.adk.apps.app as adk_app
 from google.genai.types import Part
+from vertexai.preview import rag
+
 
 # Add text/markdown mimetype for .md files
 mimetypes.add_type("text/markdown", ".md")
@@ -69,6 +65,7 @@ logger = logging.getLogger(__name__)
 # Silence the harmless but noisy InMemorySessionService warning inside sub-agents
 original_append_event = im_session.InMemorySessionService.append_event
 
+
 async def _patched_append_event(self, session, event):
     app_name = session.app_name
     user_id = session.user_id
@@ -84,16 +81,19 @@ async def _patched_append_event(self, session, event):
 
     return await original_append_event(self, session, event)
 
+
 im_session.InMemorySessionService.append_event = _patched_append_event
 
 
 # Monkey-patch validate_app_name to prevent ADK 2.0 serialization errors
 original_validate_app_name = adk_app.validate_app_name
 
+
 def _patched_validate_app_name(name: str) -> None:
     if re.match(r"^\d+$", name):
         return
     return original_validate_app_name(name)
+
 
 adk_app.validate_app_name = _patched_validate_app_name
 # -------------------------------------------------------------------------
@@ -183,7 +183,7 @@ class DynamicMcpToolset(McpToolset):
             container_env = dict(os.environ)
             container_env["PYTHONPATH"] = (
                 ":".join(sys.path)
-                + ":external/mcp-security/server/secops:external/mcp-security/server/secops-soar:external/mcp-security/server/gti:external/mcp-security/server/scc"
+                + ":/code/external/mcp-security/server/secops:/code/external/mcp-security/server/secops-soar:/code/external/mcp-security/server/gti:/code/external/mcp-security/server/scc"
             )
 
             for k, v in self.target_env.items():
@@ -289,6 +289,7 @@ async def before_tool_cache(tool, args, tool_context: Context, **kwargs):
             and hasattr(tool_context, "_invocation_context")
             and getattr(tool_context._invocation_context, "memory_service", None)
         ):
+
             async def _shared_search_memory(self, query: str):
                 return await self._invocation_context.memory_service.search_memory(
                     app_name=self._invocation_context.app_name,
@@ -297,6 +298,7 @@ async def before_tool_cache(tool, args, tool_context: Context, **kwargs):
                 )
 
             import types
+
             tool_context.search_memory = types.MethodType(
                 _shared_search_memory, tool_context
             )
@@ -398,6 +400,7 @@ async def save_report_artifact(filename: str, report_content: str, ctx: Context)
 
                     try:
                         from datetime import timedelta
+
                         from google.cloud import storage
 
                         storage_client = storage.Client()
@@ -410,7 +413,9 @@ async def save_report_artifact(filename: str, report_content: str, ctx: Context)
                         link_to_provide = f"[{filename}]({signed_url})"
                     except Exception as sign_e:
                         logger.warning(f"Could not generate signed url: {sign_e}")
-                        gcs_url = f"https://storage.cloud.google.com/{bucket}/{blob_name}"
+                        gcs_url = (
+                            f"https://storage.cloud.google.com/{bucket}/{blob_name}"
+                        )
                         link_to_provide = f"[{filename}]({gcs_url})"
         except Exception as link_e:
             logger.warning(
@@ -434,7 +439,7 @@ def create_agent():
     load_dotenv(Path(".env"), override=True)
 
     # Model Configuration
-    TIER2_RESPONDER_MODEL = os.environ.get("TIER2_RESPONDER_MODEL", "gemini-3.5-flash")
+    TIER2_RESPONDER_MODEL = os.environ.get("TIER2_RESPONDER_MODEL", "gemini-2.5-pro")
 
     # Get all required environment variables
     GCP_PROJECT_ID = os.environ.get("GCP_PROJECT_ID")
@@ -449,9 +454,13 @@ def create_agent():
     CHRONICLE_SERVICE_ACCOUNT_PATH = os.environ.get("CHRONICLE_SERVICE_ACCOUNT_PATH")
 
     if not CHRONICLE_PROJECT_ID:
-        raise ValueError("CHRONICLE_PROJECT_ID is required. Please set it in your .env file.")
+        raise ValueError(
+            "CHRONICLE_PROJECT_ID is required. Please set it in your .env file."
+        )
     if not CHRONICLE_SERVICE_ACCOUNT_PATH:
-        raise ValueError("CHRONICLE_SERVICE_ACCOUNT_PATH is required. Please set it in your .env file.")
+        raise ValueError(
+            "CHRONICLE_SERVICE_ACCOUNT_PATH is required. Please set it in your .env file."
+        )
 
     # Verify service account file exists
     service_account_path = Path(CHRONICLE_SERVICE_ACCOUNT_PATH)
@@ -460,14 +469,59 @@ def create_agent():
             f"Chronicle service account file not found: {CHRONICLE_SERVICE_ACCOUNT_PATH}"
         )
 
+    # RAG configuration
+    RAG_CORPUS_ID = os.environ.get("RAG_CORPUS_ID")
+    RAG_LOCATION = os.environ.get("RAG_LOCATION") or os.environ.get("RAG_GCP_LOCATION")
+
+    # Determine location: use RAG location if configured/parseable, otherwise deployment location
+    init_location = GCP_LOCATION
+    if RAG_CORPUS_ID:
+        # Parse project and location from corpus resource name
+        # Format: projects/PROJECT_ID/locations/LOCATION/ragCorpora/CORPUS_ID
+        if "/" in RAG_CORPUS_ID:
+            parts = RAG_CORPUS_ID.split("/")
+            if len(parts) >= 4:
+                rag_project_id = parts[1]
+                rag_location = parts[3]
+
+                # Fail fast and noisy on project mismatch
+                if rag_project_id != GCP_PROJECT_ID:
+                    raise ValueError(
+                        f"PROJECT MISMATCH: The GCP_PROJECT_ID in your environment ({GCP_PROJECT_ID}) "
+                        f"does not match the project ID embedded in your RAG_CORPUS_ID ({rag_project_id}). "
+                        f"Please align them in your .env file."
+                    )
+
+                # Fail fast and noisy on location mismatch if explicitly configured
+                if RAG_LOCATION and RAG_LOCATION != rag_location:
+                    raise ValueError(
+                        f"LOCATION MISMATCH: The RAG_LOCATION/RAG_GCP_LOCATION in your environment ({RAG_LOCATION}) "
+                        f"does not match the location embedded in your RAG_CORPUS_ID ({rag_location}). "
+                        f"Please align them in your .env file."
+                    )
+            else:
+                rag_location = "us-east4"
+        else:
+            rag_location = "us-east4"
+
+        init_location = rag_location
+        logger.info("Initializing Vertex AI for RAG corpus access")
+        logger.info(f"  Project: {GCP_PROJECT_ID}")
+        logger.info(f"  RAG location: {rag_location}")
+    else:
+        logger.info("Initializing Vertex AI for model access")
+        logger.info(f"  Project: {GCP_PROJECT_ID}")
+        logger.info(f"  Location: {init_location}")
+
     # Initialize Vertex AI for the agent to work with Gemini models and RAG
-    if GCP_PROJECT_ID and GCP_VERTEXAI_ENABLED == "True":
-        logger.info(
-            f"Initializing Vertex AI with project: {GCP_PROJECT_ID}, location: {GCP_LOCATION}"
-        )
+    if (
+        GCP_PROJECT_ID
+        and GCP_VERTEXAI_ENABLED
+        and GCP_VERTEXAI_ENABLED.upper() == "TRUE"
+    ):
         vertexai.init(
             project=GCP_PROJECT_ID,
-            location=GCP_LOCATION,
+            location=init_location,
             staging_bucket=GCP_STAGING_BUCKET,
         )
 
@@ -477,9 +531,6 @@ def create_agent():
 
     # Google Threat Intelligence configuration
     GTI_API_KEY = os.environ.get("GTI_API_KEY")
-
-    # RAG configuration
-    RAG_CORPUS_ID = os.environ.get("RAG_CORPUS_ID")
 
     try:
         RAG_SIMILARITY_TOP_K = int(os.environ.get("RAG_SIMILARITY_TOP_K", "10"))
@@ -577,8 +628,6 @@ def create_agent():
 
     # ========================================================================
     # Add google_search as a standalone tool
-    # ========================================================================
-    tools.append(google_search)
 
     # ========================================================================
     # Add save_report_artifact as a standalone tool
@@ -597,27 +646,32 @@ def create_agent():
             notify_human_incident,
             request_human_confirmation,
             send_chatops_card,
-            trigger_vulnerability_patch_approval_card,
+            trigger_ai_brute_force_source_block_card,
+            trigger_ai_data_exfiltration_block_card,
             trigger_ai_malicious_container_kill_card,
             trigger_ai_wipe_host_approval_card,
-            trigger_ai_data_exfiltration_block_card,
-            trigger_ai_brute_force_source_block_card,
+            trigger_vulnerability_patch_approval_card,
         )
-        tools.extend([
-            deliver_report,
-            generic_notification,
-            list_chatops_capabilities,
-            notify_human_incident,
-            request_human_confirmation,
-            send_chatops_card,
-            trigger_vulnerability_patch_approval_card,
-            trigger_ai_malicious_container_kill_card,
-            trigger_ai_wipe_host_approval_card,
-            trigger_ai_data_exfiltration_block_card,
-            trigger_ai_brute_force_source_block_card,
-        ])
+
+        tools.extend(
+            [
+                deliver_report,
+                generic_notification,
+                list_chatops_capabilities,
+                notify_human_incident,
+                request_human_confirmation,
+                send_chatops_card,
+                trigger_vulnerability_patch_approval_card,
+                trigger_ai_malicious_container_kill_card,
+                trigger_ai_wipe_host_approval_card,
+                trigger_ai_data_exfiltration_block_card,
+                trigger_ai_brute_force_source_block_card,
+            ]
+        )
     except ImportError as import_e:
-        logger.warning(f"Could not import ChatOps tools directly: {import_e}. Proceeding with MCP tools only.")
+        logger.warning(
+            f"Could not import ChatOps tools directly: {import_e}. Proceeding with MCP tools only."
+        )
 
     # ========================================================================
     # Create the Agent with all configured tools

--- a/agent_a2a_tier2/agent.py
+++ b/agent_a2a_tier2/agent.py
@@ -96,6 +96,131 @@ def _patched_validate_app_name(name: str) -> None:
 
 
 adk_app.validate_app_name = _patched_validate_app_name
+
+
+# -------------------------------------------------------------------------
+
+
+from collections.abc import AsyncGenerator  # noqa: E402
+
+from google.adk.agents.invocation_context import InvocationContext  # noqa: E402
+from google.adk.agents.sequential_agent import Event  # noqa: E402
+
+
+_runtime_patches_applied = False
+
+
+def _apply_runtime_patches():
+    global _runtime_patches_applied
+    if _runtime_patches_applied:
+        return
+
+    import logging
+
+    logger = logging.getLogger(__name__)
+    logger.warning(
+        "[RUNTIME_PATCH_DEBUG] Applying runtime framework monkeypatches inside Reasoning Engine process..."
+    )
+
+    # 1. Monkeypatch validation function to prevent 400 INVALID_ARGUMENT when removing function call IDs
+    try:
+        import google.adk.flows.llm_flows.contents as adk_contents
+        import google.adk.flows.llm_flows.functions as adk_funcs
+
+        def _patched_remove_client_function_call_id(content) -> None:
+            pass
+
+        adk_funcs.remove_client_function_call_id = (
+            _patched_remove_client_function_call_id
+        )
+        adk_contents.remove_client_function_call_id = (
+            _patched_remove_client_function_call_id
+        )
+        logger.warning(
+            "[RUNTIME_PATCH_DEBUG] Successfully patched remove_client_function_call_id"
+        )
+    except Exception as e:
+        logger.warning(
+            f"[RUNTIME_PATCH_DEBUG] Failed to patch remove_client_function_call_id: {e}"
+        )
+
+    # 2. Monkeypatch McpTool._get_declaration to strip response_json_schema
+    try:
+        from google.adk.tools.mcp_tool.mcp_tool import McpTool
+        from google.genai.types import FunctionDeclaration
+
+        def _patched_get_declaration(self) -> FunctionDeclaration:
+            input_schema = self._mcp_tool.inputSchema
+            return FunctionDeclaration(
+                name=self.name,
+                description=self.description,
+                parameters_json_schema=input_schema,
+                response_json_schema=None,
+            )
+
+        McpTool._get_declaration = _patched_get_declaration
+        logger.warning(
+            "[RUNTIME_PATCH_DEBUG] Successfully patched McpTool._get_declaration"
+        )
+    except Exception as e:
+        logger.warning(
+            f"[RUNTIME_PATCH_DEBUG] Failed to patch McpTool._get_declaration: {e}"
+        )
+
+    # 3. Monkeypatch encode_unserializable_types to preserve standard base64 encoding for thought_signature bytes
+    try:
+        import base64
+
+        import google.genai._common as genai_common
+
+        original_encode = genai_common.encode_unserializable_types
+
+        def _patched_encode_unserializable_types(data):
+            if isinstance(data, dict):
+                processed = {}
+                for k, v in data.items():
+                    if k in ("thought_signature", "thoughtSignature") and isinstance(
+                        v, bytes
+                    ):
+                        processed[k] = base64.b64encode(v).decode("ascii")
+                    elif isinstance(v, dict):
+                        processed[k] = _patched_encode_unserializable_types(v)
+                    elif isinstance(v, list):
+                        processed[k] = [
+                            _patched_encode_unserializable_types(item)
+                            if isinstance(item, dict)
+                            else item
+                            for item in v
+                        ]
+                    else:
+                        processed[k] = v
+                return original_encode(processed)
+            return original_encode(data)
+
+        genai_common.encode_unserializable_types = _patched_encode_unserializable_types
+        logger.warning(
+            "[RUNTIME_PATCH_DEBUG] Successfully patched encode_unserializable_types"
+        )
+    except Exception as e:
+        logger.warning(
+            f"[RUNTIME_PATCH_DEBUG] Failed to patch encode_unserializable_types: {e}"
+        )
+
+    _runtime_patches_applied = True
+    logger.warning("[RUNTIME_PATCH_DEBUG] All runtime patches applied successfully!")
+
+
+class PatchedAgent(Agent):
+
+    async def run_async(
+        self,
+        parent_context: InvocationContext,
+    ) -> AsyncGenerator[Event, None]:
+        _apply_runtime_patches()
+        async for event in super().run_async(parent_context):
+            yield event
+
+
 # -------------------------------------------------------------------------
 
 
@@ -678,7 +803,7 @@ def create_agent():
     # ========================================================================
     logger.info(f"Creating Tier 2 Incident Responder Agent with {len(tools)} tools...")
 
-    agent = Agent(
+    agent = PatchedAgent(
         model=TIER2_RESPONDER_MODEL,
         name="soc_analyst_tier2_responder",
         description=TIER2_PERSONA,

--- a/agent_a2a_tier2/agent.py
+++ b/agent_a2a_tier2/agent.py
@@ -206,6 +206,78 @@ def _apply_runtime_patches():
             f"[RUNTIME_PATCH_DEBUG] Failed to patch encode_unserializable_types: {e}"
         )
 
+    # 4. Monkeypatch lite_llm._decode_thought_signature to normalize URL-safe base64 strings
+    try:
+        import google.adk.models.lite_llm as adk_lite_llm
+
+        def _patched_decode_thought_signature(value):
+            if isinstance(value, bytes):
+                return value
+            if isinstance(value, str):
+                normalized = value.replace("-", "+").replace("_", "/")
+                padding_needed = (4 - len(normalized) % 4) % 4
+                normalized += "=" * padding_needed
+                try:
+                    return base64.b64decode(normalized, validate=True)
+                except Exception as e:
+                    logger.debug("Failed to decode thought signature in patch: %s", e)
+            return None
+
+        adk_lite_llm._decode_thought_signature = _patched_decode_thought_signature
+        logger.warning(
+            "[RUNTIME_PATCH_DEBUG] Successfully patched lite_llm._decode_thought_signature"
+        )
+    except Exception as e:
+        logger.warning(
+            f"[RUNTIME_PATCH_DEBUG] Failed to patch lite_llm._decode_thought_signature: {e}"
+        )
+
+    # 5. Monkeypatch part_converter base64.b64decode to normalize URL-safe base64 strings
+    try:
+        import google.adk.a2a.converters.part_converter as part_converter
+
+        original_part_b64decode = part_converter.base64.b64decode
+
+        def _patched_part_b64decode(s, *args, **kwargs):
+            if isinstance(s, str):
+                normalized = s.replace("-", "+").replace("_", "/")
+                padding_needed = (4 - len(normalized) % 4) % 4
+                normalized += "=" * padding_needed
+                return original_part_b64decode(normalized, *args, **kwargs)
+            return original_part_b64decode(s, *args, **kwargs)
+
+        part_converter.base64.b64decode = _patched_part_b64decode
+        logger.warning(
+            "[RUNTIME_PATCH_DEBUG] Successfully patched part_converter base64.b64decode"
+        )
+    except Exception as e:
+        logger.warning(
+            f"[RUNTIME_PATCH_DEBUG] Failed to patch part_converter base64.b64decode: {e}"
+        )
+
+    # 6. Monkeypatch interactions_utils base64.b64decode to normalize URL-safe base64 strings
+    try:
+        import google.adk.models.interactions_utils as interactions_utils
+
+        original_utils_b64decode = interactions_utils.base64.b64decode
+
+        def _patched_utils_b64decode(s, *args, **kwargs):
+            if isinstance(s, str):
+                normalized = s.replace("-", "+").replace("_", "/")
+                padding_needed = (4 - len(normalized) % 4) % 4
+                normalized += "=" * padding_needed
+                return original_utils_b64decode(normalized, *args, **kwargs)
+            return original_utils_b64decode(s, *args, **kwargs)
+
+        interactions_utils.base64.b64decode = _patched_utils_b64decode
+        logger.warning(
+            "[RUNTIME_PATCH_DEBUG] Successfully patched interactions_utils base64.b64decode"
+        )
+    except Exception as e:
+        logger.warning(
+            f"[RUNTIME_PATCH_DEBUG] Failed to patch interactions_utils base64.b64decode: {e}"
+        )
+
     _runtime_patches_applied = True
     logger.warning("[RUNTIME_PATCH_DEBUG] All runtime patches applied successfully!")
 

--- a/agent_soc_manager/agent.py
+++ b/agent_soc_manager/agent.py
@@ -128,6 +128,31 @@ def _patched_validate_app_name(name: str) -> None:
 
 
 adk_app.validate_app_name = _patched_validate_app_name
+
+# Monkey-patch remove_client_function_call_id to preserve function call/response IDs on Vertex Reasoning Engine.
+# Stripping these IDs causes 400 INVALID_ARGUMENT on multi-turn/tool-response queries.
+import google.adk.flows.llm_flows.contents as adk_contents  # noqa: E402
+import google.adk.flows.llm_flows.functions as adk_funcs  # noqa: E402
+
+
+def _patched_remove_client_function_call_id(content) -> None:
+    pass
+
+
+adk_funcs.remove_client_function_call_id = _patched_remove_client_function_call_id
+adk_contents.remove_client_function_call_id = _patched_remove_client_function_call_id
+
+# Redirect LLM model request debug logs to warning level to guarantee they are logged line-by-line
+llm_logger = logging.getLogger("google_adk.google.adk.models.google_llm")
+
+
+def _patched_debug(msg, *args, **kwargs):
+    for line in str(msg).splitlines():
+        if line.strip():
+            llm_logger.warning(f"[DEBUG OVERRIDE] {line}", *args, **kwargs)
+
+
+llm_logger.debug = _patched_debug
 # -------------------------------------------------------------------------
 
 
@@ -805,39 +830,47 @@ async def delegate_to_tier2_responder(query: str, tool_context: Context) -> str:
     Args:
         query: The specific containment task or mitigation request (e.g., 'Isolate host MALWARETEST-WIN' or 'Suspend compromised user credentials').
     """
-    logger.info(f"A2A_DELEGATION: Attempting to delegate to Tier 2 Incident Responder for: {query}")
+    logger.info(
+        f"A2A_DELEGATION: Attempting to delegate to Tier 2 Incident Responder for: {query}"
+    )
     try:
         # Retrieve Tier 2 Agent Engine resource name from environment variables
         tier2_engine_name = os.environ.get("TIER2_AGENT_RESOURCE_NAME")
         if not tier2_engine_name:
-            logger.error("A2A_DELEGATION_ERROR: TIER2_AGENT_RESOURCE_NAME not set in environment.")
+            logger.error(
+                "A2A_DELEGATION_ERROR: TIER2_AGENT_RESOURCE_NAME not set in environment."
+            )
             return "Error: Tier 2 Incident Responder is not currently configured in the environment."
 
         # Get the remote Reasoning Engine client
         from vertexai import agent_engines
+
         remote_engine = agent_engines.get(tier2_engine_name)
-        
+
         # Retrieve session context parameters
         session_id = None  # Let remote specialist auto-create its own session to prevent SessionNotFoundError
         user_id = "secops_assistant"
-        
+
         # Map parent context to child session if available
-        if hasattr(tool_context, "_invocation_context") and tool_context._invocation_context:
+        if (
+            hasattr(tool_context, "_invocation_context")
+            and tool_context._invocation_context
+        ):
             root_ctx = tool_context._invocation_context
             if hasattr(root_ctx, "user_id"):
                 user_id = root_ctx.user_id
 
-        logger.info(f"A2A_DELEGATION: Calling remote Tier 2 agent ({tier2_engine_name}) with User: {user_id}")
-        
+        logger.info(
+            f"A2A_DELEGATION: Calling remote Tier 2 agent ({tier2_engine_name}) with User: {user_id}"
+        )
+
         # Invoke the remote engine client dynamically accumulating streaming events
         response_parts = []
         async for event in remote_engine.async_stream_query(
-            user_id=user_id,
-            session_id=session_id,
-            message=query
+            user_id=user_id, session_id=session_id, message=query
         ):
             logger.debug(f"A2A_DELEGATION_EVENT: {event}")
-            
+
             # Safe lookup helper supporting both dict and object structures interchangeably
             def get_field(obj, field_name):
                 if obj is None:
@@ -856,27 +889,41 @@ async def delegate_to_tier2_responder(query: str, tool_context: Context) -> str:
                         text = get_field(part, "text")
                         if text:
                             response_parts.append(text)
-                        
+
                         # 2. Extract tool/function calls for real-time status updates
                         function_call = get_field(part, "function_call")
                         if function_call:
                             name = get_field(function_call, "name")
-                            if name in ["request_human_confirmation", "request_triage_approval"]:
-                                response_parts.append("[Specialist Action] Dispatched a high-priority ChatOps confirmation card to the security operations channel requesting human analyst approval before executing containment.")
+                            if name in [
+                                "request_human_confirmation",
+                                "request_triage_approval",
+                            ]:
+                                response_parts.append(
+                                    "[Specialist Action] Dispatched a high-priority ChatOps confirmation card to the security operations channel requesting human analyst approval before executing containment."
+                                )
                             elif name == "deliver_report":
-                                response_parts.append("[Specialist Action] Saved and delivered the incident containment report to the security operations channel.")
+                                response_parts.append(
+                                    "[Specialist Action] Saved and delivered the incident containment report to the security operations channel."
+                                )
                             else:
-                                response_parts.append(f"[Specialist Action] Invoking containment tool: {name}")
+                                response_parts.append(
+                                    f"[Specialist Action] Invoking containment tool: {name}"
+                                )
 
         final_text = "".join(response_parts).strip()
         if not final_text:
             final_text = "The Tier 2 specialist completed the request without generating a text response."
 
         logger.info("A2A_DELEGATION_SUCCESS: Successfully completed remote A2A call.")
-        return f"--- Response from Tier 2 Incident Responder Specialist ---\n{final_text}"
-        
+        return (
+            f"--- Response from Tier 2 Incident Responder Specialist ---\n{final_text}"
+        )
+
     except Exception as e:
-        logger.error(f"A2A_DELEGATION_ERROR: Failed to delegate task to Tier 2 agent: {e}", exc_info=True)
+        logger.error(
+            f"A2A_DELEGATION_ERROR: Failed to delegate task to Tier 2 agent: {e}",
+            exc_info=True,
+        )
         return f"Failed to communicate with the remote Tier 2 Incident Responder specialist agent: {e}"
 
 
@@ -927,7 +974,9 @@ def create_agent():
     logger.warning(
         f"AUTH_DEBUG [agent_soc_manager]: CHRONICLE_PROJECT_ID={CHRONICLE_PROJECT_ID}"
     )
-    logger.warning(f"AUTH_DEBUG [agent_soc_manager]: CHRONICLE_REGION={CHRONICLE_REGION}")
+    logger.warning(
+        f"AUTH_DEBUG [agent_soc_manager]: CHRONICLE_REGION={CHRONICLE_REGION}"
+    )
     logger.warning(
         f"AUTH_DEBUG [agent_soc_manager]: CHRONICLE_SERVICE_ACCOUNT_PATH={CHRONICLE_SERVICE_ACCOUNT_PATH}"
     )
@@ -1002,7 +1051,9 @@ def create_agent():
         )
         mcp_env["CHRONICLE_SERVICE_ACCOUNT_SECRET"] = CHRONICLE_SERVICE_ACCOUNT_SECRET
     elif service_account_filename:
-        logger.warning("AUTH_DEBUG [agent_soc_manager]: Adding SECOPS_SA_PATH to mcp_env")
+        logger.warning(
+            "AUTH_DEBUG [agent_soc_manager]: Adding SECOPS_SA_PATH to mcp_env"
+        )
         # Ensure we use the filename (not absolute path) so it works in the container where the file is copied.
         # For local execution, use the absolute path since the file isn't copied to the runner CWD.
         if os.environ.get("REASONING_ENGINE_DEPLOYMENT") == "True":

--- a/agent_soc_manager/agent.py
+++ b/agent_soc_manager/agent.py
@@ -15,7 +15,11 @@ mimetypes.add_type("text/markdown", ".md")
 # This workaround routes model API calls to global while keeping Reasoning Engine regional
 # See: https://github.com/google/adk-python/issues/3628#issuecomment-3595215761
 os.environ["GOOGLE_CLOUD_LOCATION"] = "global"
-os.environ["GOOGLE_GENAI_USE_VERTEXAI"] = "TRUE"
+if "GOOGLE_GENAI_USE_VERTEXAI" not in os.environ:
+    if os.environ.get("REASONING_ENGINE_DEPLOYMENT") == "True":
+        os.environ["GOOGLE_GENAI_USE_VERTEXAI"] = "TRUE"
+    else:
+        os.environ["GOOGLE_GENAI_USE_VERTEXAI"] = "FALSE"
 
 """
 SOC Agent Module - Orchestrator with Sub-Agent Delegation
@@ -297,8 +301,11 @@ PYTHON_EXECUTABLE = (
 
 
 try:
-    logging_client = google.cloud.logging.Client()
-    logging_client.setup_logging()
+    if os.environ.get("REASONING_ENGINE_DEPLOYMENT") == "True":
+        logging_client = google.cloud.logging.Client()
+        logging_client.setup_logging()
+    else:
+        logging.basicConfig(level=logging.INFO)
 except Exception as e:
     print(f"Warning: Cloud logging initialization failed: {e}")
 
@@ -1195,7 +1202,6 @@ CRITICAL: When formulating analysis plans, summarize your approach and ask for u
         after_tool_callback=after_tool_cache,
         after_agent_callback=generate_memory,
         generate_content_config=strict_config,
-        mode="task",
         disallow_transfer_to_peers=True,
     )
 
@@ -1334,7 +1340,6 @@ CRITICAL: Summarize procedures and ask for user permission before executing stat
         after_tool_callback=after_tool_cache,
         after_agent_callback=generate_memory,
         generate_content_config=strict_config,
-        mode="task",
         disallow_transfer_to_peers=True,
     )
 
@@ -1581,7 +1586,6 @@ Remember: Your role is to be an intelligent orchestrator that makes security ope
         after_tool_callback=after_tool_cache,
         after_agent_callback=generate_memory,
         generate_content_config=strict_config,
-        mode="chat",
     )
 
     tools_description = []

--- a/agent_soc_manager/agent.py
+++ b/agent_soc_manager/agent.py
@@ -65,7 +65,6 @@ See PR #25 discussion for additional context on this architectural decision.
 # Framework Monkey-Patches
 # -------------------------------------------------------------------------
 import google.adk.sessions.in_memory_session_service as im_session  # noqa: E402
-import google.cloud.logging  # noqa: E402
 import vertexai  # noqa: E402
 from dotenv import load_dotenv  # noqa: E402
 from google.adk.agents import Agent  # noqa: E402
@@ -322,17 +321,14 @@ PYTHON_EXECUTABLE = (
     else sys.executable
 )
 
-# Configure logging
-
-
-try:
-    if os.environ.get("REASONING_ENGINE_DEPLOYMENT") == "True":
-        logging_client = google.cloud.logging.Client()
-        logging_client.setup_logging()
-    else:
-        logging.basicConfig(level=logging.INFO)
-except Exception as e:
-    print(f"Warning: Cloud logging initialization failed: {e}")
+# Configure logging to write to stdout/stderr so that Vertex AI automatically
+# captures and associates them with the ReasoningEngine resource.
+# Avoids direct Cloud Logging API handler setup to prevent resource tag mismatches.
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    stream=sys.stdout,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -841,11 +837,23 @@ async def delegate_to_tier2_responder(query: str, tool_context: Context) -> str:
                 "A2A_DELEGATION_ERROR: TIER2_AGENT_RESOURCE_NAME not set in environment."
             )
             return "Error: Tier 2 Incident Responder is not currently configured in the environment."
+        # Parse the location from the resource name dynamically
+        import re
 
-        # Get the remote Reasoning Engine client
-        from vertexai import agent_engines
+        m = re.search(r"locations/([^/]+)/", tier2_engine_name)
+        target_location = m.group(1) if m else "us-east4"
 
-        remote_engine = agent_engines.get(tier2_engine_name)
+        # Clean Regional Routing:
+        # Instead of using the global 'vertexai.agent_engines.get' shortcut (which
+        # is bound to the global client pool and impacted by the GOOGLE_CLOUD_LOCATION="global"
+        # LLM workaround), we explicitly construct a regional 'vertexai.Client' instance.
+        # This guarantees an isolated, correct regional gRPC pathway for A2A.
+        import vertexai
+
+        client = vertexai.Client(
+            project=os.environ.get("GCP_PROJECT_ID"), location=target_location
+        )
+        remote_engine = client.agent_engines.get(name=tier2_engine_name)
 
         # Retrieve session context parameters
         session_id = None  # Let remote specialist auto-create its own session to prevent SessionNotFoundError
@@ -1105,6 +1113,7 @@ def create_agent():
     RAG_CORPUS_ID = os.environ.get("RAG_CORPUS_ID")
     RAG_SIMILARITY_TOP_K = int(os.environ.get("RAG_SIMILARITY_TOP_K", "10"))
     RAG_DISTANCE_THRESHOLD = float(os.environ.get("RAG_DISTANCE_THRESHOLD", "0.6"))
+    RAG_GCP_LOCATION = os.environ.get("RAG_GCP_LOCATION")
 
     # Debug mode
     DEBUG = os.environ.get("DEBUG", "False") == "True"
@@ -1120,14 +1129,42 @@ def create_agent():
     skip_vertexai_init = os.environ.get("SKIP_VERTEXAI_INIT", "False") == "True"
 
     # Always initialize Vertex AI when enabled, using appropriate location
-    if not skip_vertexai_init and GCP_PROJECT_ID and GCP_VERTEXAI_ENABLED == "True":
+    if (
+        not skip_vertexai_init
+        and GCP_PROJECT_ID
+        and GCP_VERTEXAI_ENABLED
+        and GCP_VERTEXAI_ENABLED.upper() == "TRUE"
+    ):
         # Determine location: use RAG location if RAG is configured, otherwise deployment location
         if RAG_CORPUS_ID:
-            # Parse RAG location from corpus resource name
+            # Parse project and location from corpus resource name
             # Format: projects/PROJECT_ID/locations/LOCATION/ragCorpora/CORPUS_ID
-            rag_location = (
-                RAG_CORPUS_ID.split("/")[3] if "/" in RAG_CORPUS_ID else "us-east4"
-            )
+            if "/" in RAG_CORPUS_ID:
+                parts = RAG_CORPUS_ID.split("/")
+                if len(parts) >= 4:
+                    rag_project_id = parts[1]
+                    rag_location = parts[3]
+
+                    # Fail fast and noisy on project mismatch
+                    if rag_project_id != GCP_PROJECT_ID:
+                        raise ValueError(
+                            f"PROJECT MISMATCH: The GCP_PROJECT_ID in your environment ({GCP_PROJECT_ID}) "
+                            f"does not match the project ID embedded in your RAG_CORPUS_ID ({rag_project_id}). "
+                            f"Please align them in your .env file."
+                        )
+
+                    # Fail fast and noisy on location mismatch if explicitly configured
+                    if RAG_GCP_LOCATION and RAG_GCP_LOCATION != rag_location:
+                        raise ValueError(
+                            f"LOCATION MISMATCH: The RAG_GCP_LOCATION in your environment ({RAG_GCP_LOCATION}) "
+                            f"does not match the location embedded in your RAG_CORPUS_ID ({rag_location}). "
+                            f"Please align them in your .env file."
+                        )
+                else:
+                    rag_location = "us-east4"
+            else:
+                rag_location = "us-east4"
+
             init_location = rag_location
             logger.info("Initializing Vertex AI for RAG corpus access")
             logger.info(f"  Project: {GCP_PROJECT_ID}")

--- a/agent_soc_manager/agent.py
+++ b/agent_soc_manager/agent.py
@@ -185,6 +185,78 @@ def _apply_runtime_patches():
             f"[RUNTIME_PATCH_DEBUG] Failed to patch encode_unserializable_types: {e}"
         )
 
+    # 4. Monkeypatch lite_llm._decode_thought_signature to normalize URL-safe base64 strings
+    try:
+        import google.adk.models.lite_llm as adk_lite_llm
+
+        def _patched_decode_thought_signature(value):
+            if isinstance(value, bytes):
+                return value
+            if isinstance(value, str):
+                normalized = value.replace("-", "+").replace("_", "/")
+                padding_needed = (4 - len(normalized) % 4) % 4
+                normalized += "=" * padding_needed
+                try:
+                    return base64.b64decode(normalized, validate=True)
+                except Exception as e:
+                    logger.debug("Failed to decode thought signature in patch: %s", e)
+            return None
+
+        adk_lite_llm._decode_thought_signature = _patched_decode_thought_signature
+        logger.warning(
+            "[RUNTIME_PATCH_DEBUG] Successfully patched lite_llm._decode_thought_signature"
+        )
+    except Exception as e:
+        logger.warning(
+            f"[RUNTIME_PATCH_DEBUG] Failed to patch lite_llm._decode_thought_signature: {e}"
+        )
+
+    # 5. Monkeypatch part_converter base64.b64decode to normalize URL-safe base64 strings
+    try:
+        import google.adk.a2a.converters.part_converter as part_converter
+
+        original_part_b64decode = part_converter.base64.b64decode
+
+        def _patched_part_b64decode(s, *args, **kwargs):
+            if isinstance(s, str):
+                normalized = s.replace("-", "+").replace("_", "/")
+                padding_needed = (4 - len(normalized) % 4) % 4
+                normalized += "=" * padding_needed
+                return original_part_b64decode(normalized, *args, **kwargs)
+            return original_part_b64decode(s, *args, **kwargs)
+
+        part_converter.base64.b64decode = _patched_part_b64decode
+        logger.warning(
+            "[RUNTIME_PATCH_DEBUG] Successfully patched part_converter base64.b64decode"
+        )
+    except Exception as e:
+        logger.warning(
+            f"[RUNTIME_PATCH_DEBUG] Failed to patch part_converter base64.b64decode: {e}"
+        )
+
+    # 6. Monkeypatch interactions_utils base64.b64decode to normalize URL-safe base64 strings
+    try:
+        import google.adk.models.interactions_utils as interactions_utils
+
+        original_utils_b64decode = interactions_utils.base64.b64decode
+
+        def _patched_utils_b64decode(s, *args, **kwargs):
+            if isinstance(s, str):
+                normalized = s.replace("-", "+").replace("_", "/")
+                padding_needed = (4 - len(normalized) % 4) % 4
+                normalized += "=" * padding_needed
+                return original_utils_b64decode(normalized, *args, **kwargs)
+            return original_utils_b64decode(s, *args, **kwargs)
+
+        interactions_utils.base64.b64decode = _patched_utils_b64decode
+        logger.warning(
+            "[RUNTIME_PATCH_DEBUG] Successfully patched interactions_utils base64.b64decode"
+        )
+    except Exception as e:
+        logger.warning(
+            f"[RUNTIME_PATCH_DEBUG] Failed to patch interactions_utils base64.b64decode: {e}"
+        )
+
     _runtime_patches_applied = True
     logger.warning("[RUNTIME_PATCH_DEBUG] All runtime patches applied successfully!")
 

--- a/agent_soc_manager/agent.py
+++ b/agent_soc_manager/agent.py
@@ -314,10 +314,10 @@ strict_config = GenerateContentConfig(
 )
 
 # Determine Python executable based on environment
-# In deployed Vertex AI environment, use container's Python
+# In deployed Vertex AI environment, use container's virtual env Python
 # In local development, use sys.executable (respects venv)
 PYTHON_EXECUTABLE = (
-    "python3"
+    "/code/.venv/bin/python"
     if os.environ.get("REASONING_ENGINE_DEPLOYMENT") == "True"
     else sys.executable
 )
@@ -927,6 +927,29 @@ async def delegate_to_tier2_responder(query: str, tool_context: Context) -> str:
         return f"Failed to communicate with the remote Tier 2 Incident Responder specialist agent: {e}"
 
 
+def _find_mcp_paths() -> list[str]:
+    root_dir = Path(__file__).parent.parent.absolute()
+
+    paths = []
+    target_names = {"secops", "secops-soar", "gti", "scc"}
+
+    # Check directly under root_dir (container flat packaging)
+    for name in target_names:
+        dir_path = root_dir / name
+        if dir_path.exists() and dir_path.is_dir():
+            paths.append(str(dir_path))
+
+    # Check under root_dir / "external/mcp-security/server" (local directory layout)
+    local_mcp_dir = root_dir / "external/mcp-security/server"
+    if local_mcp_dir.exists() and local_mcp_dir.is_dir():
+        for name in target_names:
+            dir_path = local_mcp_dir / name
+            if dir_path.exists() and dir_path.is_dir():
+                paths.append(str(dir_path))
+
+    return list(set(paths))
+
+
 def create_agent():
     """
     Create the SOC Orchestrator Agent with specialized sub-agents.
@@ -1018,8 +1041,20 @@ def create_agent():
     # Google Threat Intelligence configuration
     GTI_API_KEY = os.environ.get("GTI_API_KEY")
 
-    # Build environment dict for MCP servers
-    # These credentials are passed to each MCP server process
+    # Build container paths statically to ensure container compatibility when pickled
+    container_paths = [
+        "/code/external/mcp-security/server/secops",
+        "/code/external/mcp-security/server/secops-soar",
+        "/code/external/mcp-security/server/gti",
+        "/code/external/mcp-security/server/scc",
+    ]
+    mcp_paths = _find_mcp_paths()
+    all_paths = list(set(container_paths + mcp_paths))
+    current_pythonpath = os.environ.get("PYTHONPATH", "")
+    new_pythonpath = os.pathsep.join(
+        all_paths + [current_pythonpath] if current_pythonpath else all_paths
+    )
+
     mcp_env = os.environ.copy()
     mcp_env.update(
         {
@@ -1030,6 +1065,7 @@ def create_agent():
             "SOAR_APP_KEY": SOAR_APP_KEY or "",
             "VT_APIKEY": GTI_API_KEY or "",  # GTI uses VT_APIKEY
             "GCP_PROJECT_ID": GCP_PROJECT_ID or "",
+            "PYTHONPATH": new_pythonpath,
             # GTI caching configuration (latency optimization)
             "GTI_CACHE_ENABLED": os.environ.get("GTI_CACHE_ENABLED", "True"),
             "GTI_CACHE_FILE_TTL": os.environ.get("GTI_CACHE_FILE_TTL", "86400"),

--- a/agent_soc_manager/agent.py
+++ b/agent_soc_manager/agent.py
@@ -76,6 +76,7 @@ from google.adk.tools import skill_toolset  # noqa: E402
 from google.adk.tools.agent_tool import AgentTool  # noqa: E402
 from google.adk.tools.mcp_tool.mcp_session_manager import (  # noqa: E402
     StdioConnectionParams,  # noqa: E402
+    StreamableHTTPConnectionParams,  # noqa: E402
 )
 from google.adk.tools.mcp_tool.mcp_toolset import McpToolset  # noqa: E402
 from mcp import StdioServerParameters  # noqa: E402
@@ -108,6 +109,60 @@ async def _patched_append_event(self, session, event):
 
 
 im_session.InMemorySessionService.append_event = _patched_append_event
+
+
+import google.adk.sessions.vertex_ai_session_service as vertex_session  # noqa: E402
+
+
+def _clean_session_id(session_id: str | None) -> str | None:
+    if isinstance(session_id, str) and "/" in session_id:
+        return session_id.split("/")[-1]
+    return session_id
+
+
+original_get_session = vertex_session.VertexAiSessionService.get_session
+
+
+async def patched_get_session(self, *, app_name, user_id, session_id, config=None):
+    session_id = _clean_session_id(session_id)
+    return await original_get_session(
+        self, app_name=app_name, user_id=user_id, session_id=session_id, config=config
+    )
+
+
+vertex_session.VertexAiSessionService.get_session = patched_get_session
+
+original_create_session = vertex_session.VertexAiSessionService.create_session
+
+
+async def patched_create_session(
+    self, *, app_name, user_id, state=None, session_id=None, **kwargs
+):
+    session_id = _clean_session_id(session_id)
+    return await original_create_session(
+        self,
+        app_name=app_name,
+        user_id=user_id,
+        state=state,
+        session_id=session_id,
+        **kwargs,
+    )
+
+
+vertex_session.VertexAiSessionService.create_session = patched_create_session
+
+original_delete_session = vertex_session.VertexAiSessionService.delete_session
+
+
+async def patched_delete_session(self, *, app_name, user_id, session_id):
+    session_id = _clean_session_id(session_id)
+    return await original_delete_session(
+        self, app_name=app_name, user_id=user_id, session_id=session_id
+    )
+
+
+vertex_session.VertexAiSessionService.delete_session = patched_delete_session
+
 
 import re  # noqa: E402
 
@@ -958,6 +1013,48 @@ def _find_mcp_paths() -> list[str]:
     return list(set(paths))
 
 
+def get_secops_headers(context) -> dict[str, str]:
+    # Read from environment AT RUNTIME
+    chronicle_project_id = os.environ.get("CHRONICLE_PROJECT_ID")
+    gemini_auth_id = os.environ.get("GEMINI_AUTHORIZATION_ID") or os.environ.get(
+        "OAUTH_AUTH_ID"
+    )
+
+    headers = {"Accept": "text/event-stream", "Content-Type": "application/json"}
+
+    # Only add the project header if we actually have a value
+    if chronicle_project_id:
+        headers["x-goog-user-project"] = chronicle_project_id
+    else:
+        # Critical for tool execution, though list_tools might still work
+        logger.critical(
+            "CHRONICLE_PROJECT_ID is missing from environment! OneMCP tool calls *will* fail without a routing context."
+        )
+
+    if context and context.state and gemini_auth_id:
+        user_token = context.state.get(gemini_auth_id)
+        if user_token:
+            headers["Authorization"] = f"Bearer {user_token}"
+            # Log first few chars for debugging without leaking full sensitive token in recap
+            logger.info(
+                f"DEBUG: Tool Call Auth Header present (starts with: {user_token[:10]}...)"
+            )
+
+    return headers
+
+
+def create_remote_secops_toolset(region, tool_filter=None) -> McpToolset:
+    # Remote OneMCP pattern: https://chronicle.{region}.rep.googleapis.com/mcp
+    secops_mcp_url = f"https://chronicle.{region}.rep.googleapis.com/mcp"
+    logger.info(f"Initializing Remote MCP Toolset with URL: {secops_mcp_url}")
+    return McpToolset(
+        connection_params=StreamableHTTPConnectionParams(url=secops_mcp_url),
+        header_provider=get_secops_headers,
+        tool_filter=tool_filter,
+        errlog=None,  # explicitly None to prevent sys.stderr capturing (which cannot be pickled)
+    )
+
+
 def create_agent():
     """
     Create the SOC Orchestrator Agent with specialized sub-agents.
@@ -1222,37 +1319,40 @@ def create_agent():
                 ),
                 timeout=90000,  # 90 seconds (balanced timeout)
             ),
+            tool_filter=[
+                "get_ip_address_report",
+                "get_domain_report",
+                "get_file_report",
+                "get_url_report",
+                "search_iocs",
+                "get_threat_profile",
+                "list_threat_profiles",
+                "get_threat_profile_recommendations",
+                "search_threats",
+                "search_campaigns",
+                "search_threat_actors",
+                "search_malware_families",
+                "get_collection_report",
+            ],
             errlog=None,  # Suppress errlog to permit serialization
         )
     )
 
-    # Chronicle for correlation
+    # Remote OneMCP for correlation and dissemination (SIEM & SOAR unified)
     cti_tools.append(
-        McpToolset(
-            connection_params=StdioConnectionParams(
-                server_params=StdioServerParameters(
-                    command=PYTHON_EXECUTABLE,
-                    args=["-m", "secops_mcp.server"],
-                    env=mcp_env,
-                ),
-                timeout=90000,  # 90 seconds (balanced timeout)
-            ),
-            errlog=None,  # Suppress errlog to permit serialization
-        )
-    )
-
-    # SOAR for dissemination
-    cti_tools.append(
-        McpToolset(
-            connection_params=StdioConnectionParams(
-                server_params=StdioServerParameters(
-                    command=PYTHON_EXECUTABLE,
-                    args=["-m", "secops_soar_mcp.server"],
-                    env=mcp_env,
-                ),
-                timeout=90000,  # 90 seconds (balanced timeout)
-            ),
-            errlog=None,  # Suppress errlog to permit serialization
+        create_remote_secops_toolset(
+            CHRONICLE_REGION,
+            tool_filter=[
+                "list_rules",
+                "get_rule",
+                "validate_rule",
+                "evaluate_rule_coverage",
+                "generate_rules",
+                "search_entity",
+                "summarize_entity",
+                "udm_search",
+                "get_ioc_match",
+            ],
         )
     )
 
@@ -1350,33 +1450,26 @@ CRITICAL: When formulating analysis plans, summarize your approach and ask for u
         send_all_example_cards,
     ]
 
-    # Chronicle for basic entity lookups
     tier1_tools.append(
-        McpToolset(
-            connection_params=StdioConnectionParams(
-                server_params=StdioServerParameters(
-                    command=PYTHON_EXECUTABLE,
-                    args=["-m", "secops_mcp.server"],
-                    env=mcp_env,
-                ),
-                timeout=90000,  # 90 seconds (balanced timeout)
-            ),
-            errlog=None,  # Suppress errlog to permit serialization
-        )
-    )
-
-    # SOAR for case management
-    tier1_tools.append(
-        McpToolset(
-            connection_params=StdioConnectionParams(
-                server_params=StdioServerParameters(
-                    command=PYTHON_EXECUTABLE,
-                    args=["-m", "secops_soar_mcp.server"],
-                    env=mcp_env,
-                ),
-                timeout=90000,  # 90 seconds (balanced timeout)
-            ),
-            errlog=None,  # Suppress errlog to permit serialization
+        create_remote_secops_toolset(
+            CHRONICLE_REGION,
+            tool_filter=[
+                "list_rules",
+                "get_rule",
+                "list_rule_detections",
+                "list_rule_errors",
+                "search_entity",
+                "summarize_entity",
+                "get_involved_entity",
+                "list_involved_entities",
+                "udm_search",
+                "list_cases",
+                "get_case",
+                "update_case",
+                "create_case_comment",
+                "list_case_alerts",
+                "get_case_alert",
+            ],
         )
     )
 
@@ -1391,6 +1484,12 @@ CRITICAL: When formulating analysis plans, summarize your approach and ask for u
                 ),
                 timeout=90000,  # 90 seconds (balanced timeout)
             ),
+            tool_filter=[
+                "get_ip_address_report",
+                "get_domain_report",
+                "get_file_report",
+                "get_url_report",
+            ],
             errlog=None,  # Suppress errlog to permit serialization
         )
     )

--- a/agent_soc_manager/agent.py
+++ b/agent_soc_manager/agent.py
@@ -64,12 +64,16 @@ See PR #25 discussion for additional context on this architectural decision.
 # -------------------------------------------------------------------------
 # Framework Monkey-Patches
 # -------------------------------------------------------------------------
+from collections.abc import AsyncGenerator  # noqa: E402
+
 import google.adk.sessions.in_memory_session_service as im_session  # noqa: E402
 import vertexai  # noqa: E402
 from dotenv import load_dotenv  # noqa: E402
 from google.adk.agents import Agent  # noqa: E402
 from google.adk.agents.callback_context import CallbackContext  # noqa: E402
 from google.adk.agents.context import Context  # noqa: E402
+from google.adk.agents.invocation_context import InvocationContext  # noqa: E402
+from google.adk.agents.sequential_agent import Event  # noqa: E402
 from google.adk.models import LlmRequest, LlmResponse  # noqa: E402
 from google.adk.skills import load_skill_from_dir  # noqa: E402
 from google.adk.tools import skill_toolset  # noqa: E402
@@ -80,6 +84,120 @@ from google.adk.tools.mcp_tool.mcp_session_manager import (  # noqa: E402
 )
 from google.adk.tools.mcp_tool.mcp_toolset import McpToolset  # noqa: E402
 from mcp import StdioServerParameters  # noqa: E402
+
+
+_runtime_patches_applied = False
+
+
+def _apply_runtime_patches():
+    global _runtime_patches_applied
+    if _runtime_patches_applied:
+        return
+
+    import logging
+
+    logger = logging.getLogger(__name__)
+    logger.warning(
+        "[RUNTIME_PATCH_DEBUG] Applying runtime framework monkeypatches inside Reasoning Engine process..."
+    )
+
+    # 1. Monkeypatch validation function to prevent 400 INVALID_ARGUMENT when removing function call IDs
+    try:
+        import google.adk.flows.llm_flows.contents as adk_contents
+        import google.adk.flows.llm_flows.functions as adk_funcs
+
+        def _patched_remove_client_function_call_id(content) -> None:
+            pass
+
+        adk_funcs.remove_client_function_call_id = (
+            _patched_remove_client_function_call_id
+        )
+        adk_contents.remove_client_function_call_id = (
+            _patched_remove_client_function_call_id
+        )
+        logger.warning(
+            "[RUNTIME_PATCH_DEBUG] Successfully patched remove_client_function_call_id"
+        )
+    except Exception as e:
+        logger.warning(
+            f"[RUNTIME_PATCH_DEBUG] Failed to patch remove_client_function_call_id: {e}"
+        )
+
+    # 2. Monkeypatch McpTool._get_declaration to strip response_json_schema
+    try:
+        from google.adk.tools.mcp_tool.mcp_tool import McpTool
+        from google.genai.types import FunctionDeclaration
+
+        def _patched_get_declaration(self) -> FunctionDeclaration:
+            input_schema = self._mcp_tool.inputSchema
+            return FunctionDeclaration(
+                name=self.name,
+                description=self.description,
+                parameters_json_schema=input_schema,
+                response_json_schema=None,
+            )
+
+        McpTool._get_declaration = _patched_get_declaration
+        logger.warning(
+            "[RUNTIME_PATCH_DEBUG] Successfully patched McpTool._get_declaration"
+        )
+    except Exception as e:
+        logger.warning(
+            f"[RUNTIME_PATCH_DEBUG] Failed to patch McpTool._get_declaration: {e}"
+        )
+
+    # 3. Monkeypatch encode_unserializable_types to preserve standard base64 encoding for thought_signature bytes
+    try:
+        import base64
+
+        import google.genai._common as genai_common
+
+        original_encode = genai_common.encode_unserializable_types
+
+        def _patched_encode_unserializable_types(data):
+            if isinstance(data, dict):
+                processed = {}
+                for k, v in data.items():
+                    if k in ("thought_signature", "thoughtSignature") and isinstance(
+                        v, bytes
+                    ):
+                        processed[k] = base64.b64encode(v).decode("ascii")
+                    elif isinstance(v, dict):
+                        processed[k] = _patched_encode_unserializable_types(v)
+                    elif isinstance(v, list):
+                        processed[k] = [
+                            _patched_encode_unserializable_types(item)
+                            if isinstance(item, dict)
+                            else item
+                            for item in v
+                        ]
+                    else:
+                        processed[k] = v
+                return original_encode(processed)
+            return original_encode(data)
+
+        genai_common.encode_unserializable_types = _patched_encode_unserializable_types
+        logger.warning(
+            "[RUNTIME_PATCH_DEBUG] Successfully patched encode_unserializable_types"
+        )
+    except Exception as e:
+        logger.warning(
+            f"[RUNTIME_PATCH_DEBUG] Failed to patch encode_unserializable_types: {e}"
+        )
+
+    _runtime_patches_applied = True
+    logger.warning("[RUNTIME_PATCH_DEBUG] All runtime patches applied successfully!")
+
+
+class PatchedAgent(Agent):
+
+    async def run_async(
+        self,
+        parent_context: InvocationContext,
+    ) -> AsyncGenerator[Event, None]:
+        _apply_runtime_patches()
+        async for event in super().run_async(parent_context):
+            yield event
 
 
 # Silence the harmless but noisy InMemorySessionService warning inside sub-agents
@@ -207,6 +325,8 @@ def _patched_debug(msg, *args, **kwargs):
 
 
 llm_logger.debug = _patched_debug
+
+
 # -------------------------------------------------------------------------
 
 
@@ -1369,7 +1489,7 @@ def create_agent():
         )
     )
 
-    cti_subagent = Agent(
+    cti_subagent = PatchedAgent(
         name="cti_researcher",
         model=CTI_RESEARCHER_MODEL,
         description=CTI_PERSONA,
@@ -1494,7 +1614,7 @@ CRITICAL: When formulating analysis plans, summarize your approach and ask for u
         )
     )
 
-    tier1_subagent = Agent(
+    tier1_subagent = PatchedAgent(
         name="tier1_analyst",
         model=TIER1_ANALYST_MODEL,
         description=TIER1_PERSONA,
@@ -1798,7 +1918,7 @@ Query: "Investigate suspicious activity from user john.doe - get the runbook fir
 Remember: Your role is to be an intelligent orchestrator that makes security operations more efficient through smart delegation and synthesis. Transfer control to specialists when their expertise is needed."""
 
     # Create orchestrator with LLM delegation to specialists (as sub_agents or AgentTool wrappers)
-    orchestrator = Agent(
+    orchestrator = PatchedAgent(
         name="secops_assistant",
         model=ORCHESTRATOR_MODEL,
         description="SecOps Security Agent - An intelligent SOC orchestrator for Google SecOps that delegates security operations to specialized persona-based agents.",

--- a/installation_scripts/install.sh
+++ b/installation_scripts/install.sh
@@ -7,9 +7,9 @@ echo "Starting MCP server installation..."
 
 # Install MCP server packages from local directories
 # These directories are copied via extra_packages in the deployment
-pip install -e /code/mcp-security/server/gti
-pip install -e /code/mcp-security/server/secops
-pip install -e /code/mcp-security/server/secops-soar
-pip install -e /code/mcp-security/server/scc
+pip install -e /code/external/mcp-security/server/gti
+pip install -e /code/external/mcp-security/server/secops
+pip install -e /code/external/mcp-security/server/secops-soar
+pip install -e /code/external/mcp-security/server/scc
 
 echo "MCP server packages installed successfully"

--- a/installation_scripts/manage_agent_engine.py
+++ b/installation_scripts/manage_agent_engine.py
@@ -797,6 +797,7 @@ class AgentEngineManager:
                 "GCP_PROJECT_ID": os.environ.get("GCP_PROJECT_ID"),
                 "GCP_LOCATION": os.environ.get("GCP_LOCATION", "us-central1"),
                 "GCP_STAGING_BUCKET": os.environ.get("GCP_STAGING_BUCKET"),
+                "GEMINI_AUTHORIZATION_ID": os.environ.get("OAUTH_AUTH_ID"),
                 "GCP_ARTIFACT_BUCKET": os.environ.get("GCP_ARTIFACT_BUCKET"),
                 "RAG_CORPUS_ID": os.environ.get("RAG_CORPUS_ID"),
                 "SOAR_URL": os.environ.get("SOAR_URL"),
@@ -912,7 +913,7 @@ class AgentEngineManager:
                 "description": description,
                 "requirements": [
                     "cloudpickle",
-                    "google-adk~=2.1.0",
+                    "google-adk~=2.2.0",
                     # ToDo: do we REALLY need evaluation?
                     "google-cloud-aiplatform[agent-engines,evaluation]~=1.153.0",
                     "pydantic",

--- a/installation_scripts/manage_agent_engine.py
+++ b/installation_scripts/manage_agent_engine.py
@@ -851,8 +851,12 @@ class AgentEngineManager:
                 "CHATOPS_BASE_URL": os.environ.get("CHATOPS_BASE_URL"),
                 "CHRONICLE_CHATOPS_SECRET": os.environ.get("CHRONICLE_CHATOPS_SECRET"),
                 # Remote Specialist A2A Coordinates
-                "TIER2_AGENT_RESOURCE_NAME": os.environ.get("TIER2_AGENT_RESOURCE_NAME"),
-                "TIER1_AGENT_RESOURCE_NAME": os.environ.get("TIER1_AGENT_RESOURCE_NAME"),
+                "TIER2_AGENT_RESOURCE_NAME": os.environ.get(
+                    "TIER2_AGENT_RESOURCE_NAME"
+                ),
+                "TIER1_AGENT_RESOURCE_NAME": os.environ.get(
+                    "TIER1_AGENT_RESOURCE_NAME"
+                ),
             }
 
             # Add service account configuration based on authentication method
@@ -908,7 +912,8 @@ class AgentEngineManager:
                 "description": description,
                 "requirements": [
                     "cloudpickle",
-                    "google-adk~=2.0.0",
+                    "google-adk~=2.1.0",
+                    # ToDo: do we REALLY need evaluation?
                     "google-cloud-aiplatform[agent-engines,evaluation]~=1.153.0",
                     "pydantic",
                     "python-dotenv",
@@ -1019,7 +1024,9 @@ class AgentEngineManager:
             # Optionally run test
             if not no_test:
                 typer.echo("\nRunning test...")
-                self.test_agent_with_resource(remote_app.resource_name, agent_module=agent_module)
+                self.test_agent_with_resource(
+                    remote_app.resource_name, agent_module=agent_module
+                )
 
             return remote_app.resource_name
 
@@ -1030,7 +1037,9 @@ class AgentEngineManager:
             typer.echo(traceback.format_exc())
             return None
 
-    def test_agent_with_resource(self, resource_name: str, agent_module: str = "soc_agent") -> bool:
+    def test_agent_with_resource(
+        self, resource_name: str, agent_module: str = "soc_agent"
+    ) -> bool:
         """
         Test a deployed agent engine with a sample query.
 
@@ -1044,6 +1053,19 @@ class AgentEngineManager:
             typer.echo("\n" + "=" * 80)
             typer.secho("Testing Agent Engine", fg=typer.colors.CYAN, bold=True)
             typer.echo("=" * 80 + "\n")
+
+            # Check location in resource name
+            m = re.search(r"locations/([^/]+)/", resource_name)
+            if m:
+                resource_location = m.group(1)
+                if resource_location != self.location:
+                    typer.secho(
+                        f"Resource location '{resource_location}' differs from default location '{self.location}'. Re-initializing Vertex AI...",
+                        fg=typer.colors.YELLOW,
+                    )
+                    self.location = resource_location
+                    vertexai.init(project=self.project, location=self.location)
+                    aiplatform.init(project=self.project, location=self.location)
 
             # Get the agent
             remote_app = agent_engines.get(resource_name)
@@ -1081,14 +1103,14 @@ class AgentEngineManager:
             else:
                 test_messages = (
                     "Use the get_ioc_matches tool for domain superstarts.top",
-                # "Get the 2 documents on Malware and then fetch_full_document for both",
-                # "List rules with ursnif in the name.",  # Chronicle SIEM MCP
-                # "List the first page of soar cases.",  # SOAR MCP
-                # memory save test
-                # "For our future investigations, please note that we have a critical asset: MALWARETEST-WIN at IP 50.90.32.142. Please acknowledge this so we have it for future reference.",
-                # soar case search test
-                # "Can you check our SOAR case management system to see if we have any currently open security cases that might relate to APT29?",
-            )
+                    # "Get the 2 documents on Malware and then fetch_full_document for both",
+                    # "List rules with ursnif in the name.",  # Chronicle SIEM MCP
+                    # "List the first page of soar cases.",  # SOAR MCP
+                    # memory save test
+                    # "For our future investigations, please note that we have a critical asset: MALWARETEST-WIN at IP 50.90.32.142. Please acknowledge this so we have it for future reference.",
+                    # soar case search test
+                    # "Can you check our SOAR case management system to see if we have any currently open security cases that might relate to APT29?",
+                )
 
             for test_message in test_messages:
                 typer.echo(f"\nSending test query: {test_message}")

--- a/installation_scripts/manage_agentspace.py
+++ b/installation_scripts/manage_agentspace.py
@@ -54,7 +54,9 @@ class AgentSpaceManager:
         """
         self.env_file = env_file
         self.env_vars = self._load_env_vars()
-        self.creds, self.project = google.auth.default()
+        self.creds, self.project = google.auth.default(
+            scopes=["https://www.googleapis.com/auth/cloud-platform"]
+        )
 
     def _load_env_vars(self) -> dict[str, str]:
         """Load environment variables from the .env file using python-dotenv."""

--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,8 @@
-google-adk~=2.1.0
+google-adk~=2.2.0
 google-cloud-aiplatform[agent-engines]~=1.153.0
 google-cloud-secret-manager
 pydantic
 python-dotenv
 google-auth-oauthlib
+mcp
 typer

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-google-adk~=2.0.0
+google-adk~=2.1.0
 google-cloud-aiplatform[agent-engines]~=1.153.0
 google-cloud-secret-manager
 pydantic

--- a/requirements.txt
+++ b/requirements.txt
@@ -75,7 +75,7 @@ fsspec==2026.4.0
     # via huggingface-hub
 gepa==0.1.1
     # via google-adk
-google-adk==2.0.0
+google-adk==2.1.0
     # via
     #   -r requirements-dev.txt
     #   -r requirements.in
@@ -357,6 +357,8 @@ python-dotenv==1.2.2
     #   -r requirements.in
     #   google-adk
     #   litellm
+python-multipart==0.0.30
+    # via google-adk
 pyyaml==6.0.3
     # via
     #   google-adk

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,9 @@ anyio==4.13.0
     # via
     #   google-genai
     #   httpx
+    #   mcp
     #   openai
+    #   sse-starlette
     #   starlette
 attrs==26.1.0
     # via
@@ -54,6 +56,7 @@ cryptography==48.0.0
     #   authlib
     #   google-auth
     #   joserfc
+    #   pyjwt
     #   pyopenssl
 distro==1.9.0
     # via
@@ -75,7 +78,7 @@ fsspec==2026.4.0
     # via huggingface-hub
 gepa==0.1.1
     # via google-adk
-google-adk==2.1.0
+google-adk==2.2.0
     # via
     #   -r requirements-dev.txt
     #   -r requirements.in
@@ -144,7 +147,7 @@ google-crc32c==1.8.0
     # via
     #   google-cloud-storage
     #   google-resumable-media
-google-genai==1.75.0
+google-genai==2.8.0
     # via
     #   google-adk
     #   google-cloud-aiplatform
@@ -195,7 +198,10 @@ httpx==0.28.1
     #   google-genai
     #   huggingface-hub
     #   litellm
+    #   mcp
     #   openai
+httpx-sse==0.4.3
+    # via mcp
 huggingface-hub==1.15.0
     # via tokenizers
 idna==3.15
@@ -225,6 +231,7 @@ jsonschema==4.23.0
     #   google-adk
     #   google-cloud-aiplatform
     #   litellm
+    #   mcp
 jsonschema-specifications==2025.9.1
     # via jsonschema
 litellm==1.83.14
@@ -233,6 +240,8 @@ markdown-it-py==4.2.0
     # via rich
 markupsafe==3.0.3
     # via jinja2
+mcp==1.27.2
+    # via -r requirements.in
 mdurl==0.1.2
     # via markdown-it-py
 multidict==6.7.1
@@ -341,11 +350,17 @@ pydantic==2.12.5
     #   google-cloud-aiplatform
     #   google-genai
     #   litellm
+    #   mcp
     #   openai
+    #   pydantic-settings
 pydantic-core==2.41.5
     # via pydantic
+pydantic-settings==2.14.1
+    # via mcp
 pygments==2.20.0
     # via rich
+pyjwt==2.13.0
+    # via mcp
 pyopenssl==26.2.0
     # via google-auth
 python-dateutil==2.9.0.post0
@@ -357,8 +372,11 @@ python-dotenv==1.2.2
     #   -r requirements.in
     #   google-adk
     #   litellm
+    #   pydantic-settings
 python-multipart==0.0.30
-    # via google-adk
+    # via
+    #   google-adk
+    #   mcp
 pyyaml==6.0.3
     # via
     #   google-adk
@@ -410,10 +428,14 @@ sniffio==1.3.1
     # via
     #   google-genai
     #   openai
-starlette==0.52.1
+sse-starlette==3.4.4
+    # via mcp
+starlette==1.2.1
     # via
     #   fastapi
     #   google-adk
+    #   mcp
+    #   sse-starlette
 tabulate==0.10.0
     # via google-adk
 tenacity==9.1.4
@@ -446,6 +468,7 @@ typing-extensions==4.15.0
     #   google-genai
     #   grpcio
     #   huggingface-hub
+    #   mcp
     #   openai
     #   opentelemetry-api
     #   opentelemetry-exporter-otlp-proto-http
@@ -461,13 +484,17 @@ typing-extensions==4.15.0
 typing-inspection==0.4.2
     # via
     #   fastapi
+    #   mcp
     #   pydantic
+    #   pydantic-settings
 tzlocal==5.3.1
     # via google-adk
 urllib3==2.7.0
     # via requests
 uvicorn==0.47.0
-    # via google-adk
+    # via
+    #   google-adk
+    #   mcp
 watchdog==6.0.0
     # via google-adk
 websockets==15.0.1


### PR DESCRIPTION
This PR upgrades google-adk to 2.2.0, monkeypatches VertexAiSessionService to support long AgentSpace session IDs, and filters GTI and OneMCP schemas to avoid exceeding LLM schema flattening limits.