### PR TITLE
docs: Service Accounts & IAM section covering deployer, end-user, service-agent, and Chronicle identities

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -3,7 +3,7 @@ type: "Documentation"
 title: "Setup Guide"
 description: "This guide will walk you through setting up your local Python environment, resolving dependency locks, and configuring the staged."
 resource: "docs/setup.md"
-timestamp: "2026-08-01T16:24:01Z"
+timestamp: "2026-08-01T22:09:35Z"
 provenance:
   source_type: "generative_ai"
   source_tool: "Antigravity"
@@ -74,3 +74,69 @@ These variables are required to link your agent with the Gemini Enterprise Agent
 - `OAUTH_CLIENT_SECRET`: The Google Cloud OAuth client secret.
 - `OAUTH_AUTH_URI`: The OAuth authorization URI.
 - `OAUTH_TOKEN_URI`: The OAuth token exchange URI.
+
+## Service Accounts & IAM
+
+Four distinct identities interact with this platform. Granting the wrong set to the wrong identity is the most common deployment failure, so they are documented separately. Official references: [Agent Engine set-up: identity and permissions](https://docs.cloud.google.com/agent-builder/agent-engine/set-up#identity-and-permissions) and [custom service accounts](https://cloud.google.com/agent-builder/agent-engine/set-up#custom-service-account).
+
+### Required APIs
+
+Enable these on the project before deploying:
+
+| API | Purpose |
+|---|---|
+| `aiplatform.googleapis.com` | Vertex AI / Agent Engine (Reasoning Engines) |
+| `discoveryengine.googleapis.com` | Gemini Enterprise apps and agent registration |
+| `storage.googleapis.com` | Staging and artifact buckets |
+| `iam.googleapis.com` | Service-account management and role grants |
+| `secretmanager.googleapis.com` | Chronicle credential storage (`just secret-upload`) |
+| `securitycenter.googleapis.com` | Optional -- SCC findings integration |
+
+### 1. The deployer (you)
+
+The human or CI identity that runs `just agent-engine-deploy` and `manage.py agentspace register` needs:
+
+| Role | Why |
+|---|---|
+| `roles/aiplatform.user` | Create and manage Reasoning Engines |
+| `roles/storage.admin` | Manage the staging bucket |
+| `roles/iam.serviceAccountUser` | Attach service accounts to agents |
+| `roles/discoveryengine.admin` | Create Gemini Enterprise apps, register agents |
+| `roles/securitycenter.admin` | Optional -- only if using SCC tools |
+
+Verify the first two with `python manage.py vertex check`; it reads the project IAM policy and reports which required roles your active credential holds.
+
+### 2. End users of the Gemini Enterprise app
+
+People who *use* the deployed app need all four of the following. Missing `discoveryengine.editor` produces the misleading error "Couldn't create a session. Contact admin for permissions."
+
+| Role | Why |
+|---|---|
+| `roles/aiplatform.user` | Invoke the Reasoning Engine |
+| `roles/aiplatform.viewer` | Read engine metadata |
+| `roles/discoveryengine.editor` | Create chat sessions (the non-obvious one) |
+| `roles/discoveryengine.viewer` | Read the app |
+
+### 3. Google-managed service agents
+
+Google creates these automatically; they follow the pattern `service-${GCP_PROJECT_NUMBER}@gcp-sa-<service>.iam.gserviceaccount.com` (project **number**, not project ID). They still need explicit role grants in your project, which `python manage.py iam setup` applies (use `--dry-run` first; `iam verify` and `iam list-roles` inspect current state):
+
+| Service agent | Roles granted | Purpose |
+|---|---|---|
+| `gcp-sa-aiplatform-re` | `roles/aiplatform.user` | Reasoning Engine queries the RAG corpus during agent execution |
+| `gcp-sa-discoveryengine` | `roles/aiplatform.user`, `roles/aiplatform.viewer` | Gemini Enterprise calls the ADK agent |
+| `gcp-sa-dialogflow` | `roles/aiplatform.user` | Conversational runtime invokes the Reasoning Engine |
+
+**Known escalation (issue #14):** some RAG-corpus operations at execution time have required `roles/aiplatform.admin` on the `gcp-sa-aiplatform-re` agent. `iam setup` deliberately grants least-privilege `aiplatform.user`; if agent-side RAG calls fail with permission errors after setup, escalate that one agent:
+
+```bash
+gcloud projects add-iam-policy-binding $GCP_PROJECT_ID \
+  --member="serviceAccount:service-${GCP_PROJECT_NUMBER}@gcp-sa-aiplatform-re.iam.gserviceaccount.com" \
+  --role="roles/aiplatform.admin"
+```
+
+Whether the granted set can be trimmed further is untested (tracked in issue #16's notes).
+
+### 4. The Chronicle service account (customer-managed)
+
+The SecOps MCP tools authenticate to Chronicle SIEM/SOAR with a key you provide -- either as a file (`CHRONICLE_SERVICE_ACCOUNT_PATH` in Stage 1) or, preferred for deployment, uploaded to Secret Manager with `just secret-upload` and referenced via `CHRONICLE_SERVICE_ACCOUNT_SECRET`. This SA is granted roles in your *Chronicle* project by your SecOps administrator; it needs no roles in the agent project.

--- a/justfile
+++ b/justfile
@@ -526,6 +526,18 @@ vertex-ai-enable-apis:
 vertex-ai-quota:
     {{ python }} {{ manage_vertex_ai }} check-quota --env-file {{ env_file }}
 
+# Grant required roles to Google-managed service agents (see docs/setup.md IAM section)
+iam-setup dry_run="false":
+    {{ python }} manage.py iam setup {{ if dry_run == "true" { "--dry-run" } else { "" } }}
+
+# Verify service-agent role grants
+iam-verify:
+    {{ python }} manage.py iam verify
+
+# List current IAM roles relevant to the platform
+iam-list-roles:
+    {{ python }} manage.py iam list-roles
+
 # List and discover available Gemini models from Google GenAI
 models-list:
     {{ python }} {{ manage_models }} list --env-file {{ env_file }}


### PR DESCRIPTION
One deliverable closing three related issues. Grounded in code probes: role sets from manage_iam.py's grant table and manage_vertex_ai.py's REQUIRED_ROLES; service-agent email pattern from _get_service_account_email (project number, not ID); end-user role set and session-error symptom from #17's report; escalation note from #14; official doc links and strip-test caveat from #16.

Fixes #14
Fixes #16
Fixes #17