### PR TITLE
Migrate ChatOps to native Google Chat App with async action execution

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,23 @@ WEBHOOK_URL=https://chat.googleapis.com/v1/spaces/SPACE_ID/messages?key=KEY&toke
 # Secret used for signing interactive button payloads (Generate a secure random string)
 CHRONICLE_CHATOPS_SECRET=your-secure-chatops-secret
 
+# ChatOps delivery mode (issue #62): "webhook" (default) posts via the
+# incoming webhook with openLink buttons; "chat_app" posts as the registered
+# Google Chat App so button clicks execute in the background (no browser tab).
+# Run `python manage.py chatops registration-guide` for the one-time setup.
+# CHATOPS_MODE=chat_app
+# Space the Chat App posts to (chat_app mode), e.g. spaces/AAAA1234
+# CHAT_SPACE=spaces/your-space-id
+# Project number: audience for verifying Google Chat interaction event JWTs
+# GCP_PROJECT_NUMBER=123456789012
+# Cloud Run URL of the deployed Chat App handler (also the worker OIDC audience)
+# CHATOPS_SERVICE_URL=https://chatops-chat-app-xyz.a.run.app
+# Cloud Tasks queue decoupling clicks from Agent Engine latency (defaults shown)
+# CHATOPS_TASKS_QUEUE=chatops-actions
+# CHATOPS_TASKS_LOCATION=us-central1
+# Service account with run.invoker on the handler; Cloud Tasks attaches its OIDC token
+# CHATOPS_INVOKER_SA=chatops-invoker@your-project-id.iam.gserviceaccount.com
+
 # RAG Corpus Configuration
 # Format: projects/PROJECT_ID/locations/LOCATION/ragCorpora/CORPUS_ID
 # (Format is validated during deployment)

--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,10 @@ CHRONICLE_CHATOPS_SECRET=your-secure-chatops-secret
 # CHATOPS_TASKS_LOCATION=us-central1
 # Service account with run.invoker on the handler; Cloud Tasks attaches its OIDC token
 # CHATOPS_INVOKER_SA=chatops-invoker@your-project-id.iam.gserviceaccount.com
+# Comma-separated emails allowed to approve actions; unset = any space member
+# CHATOPS_APPROVER_EMAILS=lead@example.com,oncall@example.com
+# Per-action Agent Engine query budget in seconds (default 540)
+# CHATOPS_AGENT_TIMEOUT=540
 
 # RAG Corpus Configuration
 # Format: projects/PROJECT_ID/locations/LOCATION/ragCorpora/CORPUS_ID

--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ Vertex AI charges per API call. Security products require separate licensing.
 
 ## Resources
 
+- [ChatOps Chat App](docs/chatops_chat_app.md) - Background approval actions in Google Chat (`CHATOPS_MODE=chat_app`)
 - [Google ADK Docs](https://google.github.io/adk-docs/) - Agent Development Kit
 - [Vertex AI Docs](https://cloud.google.com/vertex-ai/docs) - Platform documentation
 - [MCP Protocol](https://modelcontextprotocol.io/) - Model Context Protocol

--- a/agent_soc_manager/tools/chatops/Dockerfile
+++ b/agent_soc_manager/tools/chatops/Dockerfile
@@ -21,10 +21,11 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy only the ChatOps Python files.
 # We skip the entire soc_agent/ folder to keep the container small.
-COPY webhook_handler.py security.py ./
+COPY webhook_handler.py chat_app_handler.py chat_api.py security.py ./
 
 # Expose the standard Cloud Run port
 EXPOSE 8080
 
-# Run the app. Note: and our handler is inside webhook_handler.py as 'app'
-CMD ["uvicorn", "webhook_handler:app", "--host", "0.0.0.0", "--port", "8080"]
+# Run the app. chat_app_handler serves /chat/events, /tasks/execute, and
+# the legacy /action route (webhook_handler.py kept for rollback).
+CMD ["uvicorn", "chat_app_handler:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/agent_soc_manager/tools/chatops/chat_api.py
+++ b/agent_soc_manager/tools/chatops/chat_api.py
@@ -44,11 +44,23 @@ def _get_app_token() -> str:
 
 
 def _is_signed_action_url(url: str) -> bool:
-    """True when the URL is a signed ChatOps action link (/action?t=...)."""
+    """True when the URL is a signed ChatOps action link (/action?t=...).
+
+    When CHATOPS_BASE_URL is configured, the host must match it so a
+    third-party link that merely resembles an action URL is never rewritten
+    into an action button.
+    """
     parsed = urlparse(url)
     if not parsed.path.endswith("/action"):
         return False
-    return "t" in parse_qs(parsed.query)
+    if "t" not in parse_qs(parsed.query):
+        return False
+    base_url = os.environ.get("CHATOPS_BASE_URL")
+    if base_url:
+        base_host = urlparse(base_url).netloc
+        if base_host and parsed.netloc != base_host:
+            return False
+    return True
 
 
 def _extract_token(url: str) -> str | None:
@@ -99,6 +111,13 @@ def convert_openlink_to_action(card_payload: dict) -> dict:
     return payload
 
 
+async def _mint_token() -> str:
+    """Non-blocking token mint: credentials.refresh is a sync HTTP call."""
+    import asyncio
+
+    return await asyncio.to_thread(_get_app_token)
+
+
 async def post_card_as_app(space: str, card_payload: dict) -> str:
     """Posts a card message to a space as the Chat App.
 
@@ -113,7 +132,7 @@ async def post_card_as_app(space: str, card_payload: dict) -> str:
     Raises:
         httpx.HTTPStatusError: on non-2xx responses from the Chat API.
     """
-    token = _get_app_token()
+    token = await _mint_token()
     async with httpx.AsyncClient(timeout=CHAT_HTTP_TIMEOUT) as client:
         response = await client.post(
             f"{CHAT_API_BASE}/{space}/messages",
@@ -133,7 +152,7 @@ async def update_card(message_name: str, card_payload: dict) -> None:
         message_name: Full message resource name ("spaces/X/messages/Y").
         card_payload: The replacement `{"cardsV2": [...]}` payload.
     """
-    token = _get_app_token()
+    token = await _mint_token()
     async with httpx.AsyncClient(timeout=CHAT_HTTP_TIMEOUT) as client:
         response = await client.patch(
             f"{CHAT_API_BASE}/{message_name}",

--- a/agent_soc_manager/tools/chatops/chat_api.py
+++ b/agent_soc_manager/tools/chatops/chat_api.py
@@ -1,0 +1,145 @@
+"""Google Chat REST API client for native Chat App message operations.
+
+Posts and updates cards as the registered Chat App (app auth, chat.bot scope)
+instead of an incoming webhook. Webhook-posted messages cannot carry
+onClick.action payloads -- only messages posted by the app itself route
+CARD_CLICKED interaction events back to it, which is what enables the
+zero-tab approval UX (issue #62).
+
+Requires the Chat App to be registered in the same GCP project whose
+service account identity runs this code (Agent Engine SA or Cloud Run SA),
+or GOOGLE_APPLICATION_CREDENTIALS pointing at the app's service account key.
+"""
+
+import logging
+import os
+from urllib.parse import parse_qs, urlparse
+
+import httpx
+
+
+logger = logging.getLogger(__name__)
+
+CHAT_API_BASE = "https://chat.googleapis.com/v1"
+CHAT_APP_SCOPE = "https://www.googleapis.com/auth/chat.bot"
+CHAT_HTTP_TIMEOUT = float(os.environ.get("CHATOPS_HTTP_TIMEOUT", "30"))
+
+# The interaction function name carried by converted action buttons. The
+# Cloud Run handler dispatches on this name in /chat/events.
+ACTION_FUNCTION = "execute_signed_action"
+
+
+def _get_app_token() -> str:
+    """Mints an OAuth2 access token with the chat.bot scope via ADC.
+
+    google.auth is imported lazily so this module stays importable in
+    environments without GCP libraries (e.g., offline unit probes).
+    """
+    import google.auth
+    from google.auth.transport.requests import Request
+
+    credentials, _ = google.auth.default(scopes=[CHAT_APP_SCOPE])
+    credentials.refresh(Request())
+    return credentials.token
+
+
+def _is_signed_action_url(url: str) -> bool:
+    """True when the URL is a signed ChatOps action link (/action?t=...)."""
+    parsed = urlparse(url)
+    if not parsed.path.endswith("/action"):
+        return False
+    return "t" in parse_qs(parsed.query)
+
+
+def _extract_token(url: str) -> str | None:
+    """Extracts the signed token from an action URL's `t` query parameter."""
+    values = parse_qs(urlparse(url).query).get("t")
+    return values[0] if values else None
+
+
+def convert_openlink_to_action(card_payload: dict) -> dict:
+    """Rewrites signed-action openLink buttons into native Chat App actions.
+
+    This is the one-seam migration for all card templates: every template
+    builds Approve/Deny buttons through generate_action_url(), producing
+    `onClick: {openLink: {url: <base>/action?t=<signed token>}}`. In
+    chat_app mode those buttons become
+    `onClick: {action: {function: ACTION_FUNCTION, parameters: [{key:
+    "token", value: <signed token>}]}}` so clicks arrive as CARD_CLICKED
+    events instead of opening a browser tab.
+
+    Informational openLink buttons (e.g., "View in Chronicle") are left
+    untouched. The transform is idempotent and does not mutate its input.
+    """
+    import copy
+
+    payload = copy.deepcopy(card_payload)
+
+    def walk(node) -> None:
+        if isinstance(node, dict):
+            on_click = node.get("onClick")
+            if isinstance(on_click, dict) and "openLink" in on_click:
+                url = on_click["openLink"].get("url", "")
+                if _is_signed_action_url(url):
+                    token = _extract_token(url)
+                    if token:
+                        node["onClick"] = {
+                            "action": {
+                                "function": ACTION_FUNCTION,
+                                "parameters": [{"key": "token", "value": token}],
+                            }
+                        }
+            for value in node.values():
+                walk(value)
+        elif isinstance(node, list):
+            for item in node:
+                walk(item)
+
+    walk(payload)
+    return payload
+
+
+async def post_card_as_app(space: str, card_payload: dict) -> str:
+    """Posts a card message to a space as the Chat App.
+
+    Args:
+        space: Space resource name (e.g., "spaces/AAAA1234").
+        card_payload: A `{"cardsV2": [...]}` payload (webhook-shaped is fine;
+            action-button conversion is the caller's responsibility).
+
+    Returns:
+        The created message resource name (e.g., "spaces/X/messages/Y").
+
+    Raises:
+        httpx.HTTPStatusError: on non-2xx responses from the Chat API.
+    """
+    token = _get_app_token()
+    async with httpx.AsyncClient(timeout=CHAT_HTTP_TIMEOUT) as client:
+        response = await client.post(
+            f"{CHAT_API_BASE}/{space}/messages",
+            json=card_payload,
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        response.raise_for_status()
+        message_name = response.json().get("name", "")
+        logger.info(f"Posted Chat App card: {message_name}")
+        return message_name
+
+
+async def update_card(message_name: str, card_payload: dict) -> None:
+    """Replaces the cards of an existing app message (state synchronization).
+
+    Args:
+        message_name: Full message resource name ("spaces/X/messages/Y").
+        card_payload: The replacement `{"cardsV2": [...]}` payload.
+    """
+    token = _get_app_token()
+    async with httpx.AsyncClient(timeout=CHAT_HTTP_TIMEOUT) as client:
+        response = await client.patch(
+            f"{CHAT_API_BASE}/{message_name}",
+            params={"updateMask": "cardsV2"},
+            json={"cardsV2": card_payload.get("cardsV2", [])},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        response.raise_for_status()
+        logger.info(f"Updated Chat App card: {message_name}")

--- a/agent_soc_manager/tools/chatops/chat_app_handler.py
+++ b/agent_soc_manager/tools/chatops/chat_app_handler.py
@@ -1,0 +1,495 @@
+"""Native Google Chat App handler for ChatOps (issue #62).
+
+Replaces the openLink/empty-tab flow with background action execution:
+
+    POST /chat/events   Chat interaction events (CARD_CLICKED, MESSAGE,
+                        ADDED_TO_SPACE). Verifies the Google-issued bearer
+                        JWT, HMAC-verifies the signed action token, enqueues
+                        a Cloud Tasks task, and immediately returns an
+                        in-place "Processing" card update -- well inside
+                        Google Chat's 30-second response deadline.
+    POST /tasks/execute Cloud Tasks worker. Verifies the OIDC bearer token,
+                        re-verifies the HMAC token, runs the Agent Engine
+                        query (which may take minutes), then patches the
+                        original card with the confirmed outcome.
+    GET  /action        Legacy signed-URL route kept for in-flight openLink
+                        tokens during cutover (1 hour TTL).
+
+GCP-only libraries (google-auth verification, Cloud Tasks, Vertex AI) are
+imported lazily inside functions so the module imports cleanly in offline
+unit-test environments.
+"""
+
+import hashlib
+import json
+import logging
+import os
+
+from fastapi import BackgroundTasks, FastAPI, Query, Request
+from fastapi.responses import HTMLResponse, JSONResponse
+
+
+try:  # Package layout (local dev, Agent Engine extra_packages)
+    from agent_soc_manager.tools.chatops.security import verify_signed_payload
+except ImportError:  # Flat layout (Cloud Run container copies files into /app)
+    from security import verify_signed_payload
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+app = FastAPI(title="ChatOps Chat App Handler")
+
+CHAT_ISSUER = "chat@system.gserviceaccount.com"
+CHAT_CERTS_URL = (
+    "https://www.googleapis.com/service_accounts/v1/metadata/x509/"
+    "chat@system.gserviceaccount.com"
+)
+
+
+def _bearer_token(request: Request) -> str | None:
+    auth = request.headers.get("Authorization", "")
+    if auth.startswith("Bearer "):
+        return auth[len("Bearer ") :]
+    return None
+
+
+def _verify_chat_jwt(token: str) -> dict:
+    """Verifies a Google Chat interaction event bearer JWT.
+
+    Chat signs events with the chat@system.gserviceaccount.com identity;
+    the audience is this app's GCP project number.
+    """
+    from google.auth.transport.requests import Request as AuthRequest
+    from google.oauth2 import id_token
+
+    audience = os.environ.get("GCP_PROJECT_NUMBER")
+    if not audience:
+        raise ValueError("GCP_PROJECT_NUMBER is not set on the server")
+
+    claims = id_token.verify_token(
+        token, AuthRequest(), audience=audience, certs_url=CHAT_CERTS_URL
+    )
+    if claims.get("iss") != CHAT_ISSUER:
+        raise ValueError(f"Unexpected JWT issuer: {claims.get('iss')}")
+    return claims
+
+
+def _verify_tasks_oidc(token: str) -> dict:
+    """Verifies the OIDC bearer token Cloud Tasks attaches to worker calls."""
+    from google.auth.transport.requests import Request as AuthRequest
+    from google.oauth2 import id_token
+
+    audience = os.environ.get("CHATOPS_SERVICE_URL")
+    if not audience:
+        raise ValueError("CHATOPS_SERVICE_URL is not set on the server")
+    return id_token.verify_oauth2_token(token, AuthRequest(), audience=audience)
+
+
+def _extract_invoked_function(event: dict) -> tuple[str | None, dict]:
+    """Returns (function_name, parameters) from either event schema.
+
+    Chat delivers card clicks as `common.invokedFunction` + `common.parameters`
+    (newer schema) or `action.actionMethodName` + `action.parameters` (older
+    schema). Parameters normalize to a plain dict.
+    """
+    common = event.get("common") or {}
+    action = event.get("action") or {}
+
+    function = common.get("invokedFunction") or action.get("actionMethodName")
+
+    parameters: dict = {}
+    raw_common = common.get("parameters")
+    if isinstance(raw_common, dict):
+        parameters.update(raw_common)
+    raw_action = action.get("parameters")
+    if isinstance(raw_action, list):
+        for item in raw_action:
+            if isinstance(item, dict) and "key" in item:
+                parameters[item["key"]] = item.get("value")
+
+    return function, parameters
+
+
+def _processing_card(action: str, requester: str) -> dict:
+    return {
+        "cardsV2": [
+            {
+                "cardId": "chatops-processing",
+                "card": {
+                    "header": {
+                        "title": "Action In Progress",
+                        "subtitle": f"Requested by {requester}",
+                    },
+                    "sections": [
+                        {
+                            "widgets": [
+                                {
+                                    "decoratedText": {
+                                        "topLabel": "Action",
+                                        "text": action,
+                                        "startIcon": {"knownIcon": "CLOCK"},
+                                    }
+                                },
+                                {
+                                    "textParagraph": {
+                                        "text": (
+                                            "Processing... The AI agent is executing "
+                                            "this action. This card will update "
+                                            "automatically when it completes."
+                                        )
+                                    }
+                                },
+                            ]
+                        }
+                    ],
+                },
+            }
+        ]
+    }
+
+
+def _outcome_card(action: str, requester: str, succeeded: bool, detail: str) -> dict:
+    status = "Confirmed" if succeeded else "Failed"
+    icon = "STAR" if succeeded else "DESCRIPTION"
+    return {
+        "cardsV2": [
+            {
+                "cardId": "chatops-outcome",
+                "card": {
+                    "header": {
+                        "title": f"Action {status}",
+                        "subtitle": f"Requested by {requester}",
+                    },
+                    "sections": [
+                        {
+                            "widgets": [
+                                {
+                                    "decoratedText": {
+                                        "topLabel": "Action",
+                                        "text": action,
+                                        "startIcon": {"knownIcon": icon},
+                                    }
+                                },
+                                {"textParagraph": {"text": detail}},
+                            ]
+                        }
+                    ],
+                },
+            }
+        ]
+    }
+
+
+def _error_card(message: str) -> dict:
+    return {
+        "actionResponse": {"type": "UPDATE_MESSAGE"},
+        "cardsV2": [
+            {
+                "cardId": "chatops-error",
+                "card": {
+                    "header": {"title": "Action Rejected"},
+                    "sections": [{"widgets": [{"textParagraph": {"text": message}}]}],
+                },
+            }
+        ],
+    }
+
+
+def _enqueue_task(payload: dict) -> str:
+    """Enqueues the action for background execution via Cloud Tasks.
+
+    The task name is derived from the token hash, so an analyst
+    double-clicking a button dedupes to a single execution (Cloud Tasks
+    rejects duplicate task names for roughly the token's 1 hour TTL).
+    """
+    from google.cloud import tasks_v2
+
+    project = os.environ.get("GCP_PROJECT_ID")
+    location = os.environ.get("CHATOPS_TASKS_LOCATION") or os.environ.get(
+        "GCP_LOCATION", "us-central1"
+    )
+    queue = os.environ.get("CHATOPS_TASKS_QUEUE", "chatops-actions")
+    service_url = os.environ.get("CHATOPS_SERVICE_URL")
+    invoker_sa = os.environ.get("CHATOPS_INVOKER_SA")
+
+    if not project or not service_url:
+        raise ValueError("GCP_PROJECT_ID and CHATOPS_SERVICE_URL must be set")
+
+    client = tasks_v2.CloudTasksClient()
+    parent = client.queue_path(project, location, queue)
+    digest = hashlib.sha256(payload["token"].encode("utf-8")).hexdigest()[:32]
+
+    http_request = {
+        "http_method": tasks_v2.HttpMethod.POST,
+        "url": f"{service_url.rstrip('/')}/tasks/execute",
+        "headers": {"Content-Type": "application/json"},
+        "body": json.dumps(payload).encode("utf-8"),
+    }
+    if invoker_sa:
+        http_request["oidc_token"] = {
+            "service_account_email": invoker_sa,
+            "audience": service_url,
+        }
+
+    task = client.create_task(
+        request={
+            "parent": parent,
+            "task": {
+                "name": f"{parent}/tasks/act-{digest}",
+                "http_request": http_request,
+            },
+        }
+    )
+    logger.info(f"Enqueued ChatOps task: {task.name}")
+    return task.name
+
+
+async def _run_agent_query(
+    action: str, session_id: str, agent_engine_id: str, user_id: str
+) -> str:
+    """Runs the Agent Engine query for a confirmed action (may take minutes)."""
+    import vertexai
+    from vertexai import agent_engines
+
+    project = os.environ.get("GCP_PROJECT_ID")
+    location = os.environ.get("GCP_LOCATION", "us-central1")
+    if not project:
+        raise ValueError("GCP_PROJECT_ID not set on server")
+
+    vertexai.init(project=project, location=location)
+    remote_app = agent_engines.get(agent_engine_id)
+    user_input = f"USER ACTION CONFIRMED via ChatOps: {action}"
+
+    logger.info(f"Querying Agent Engine for action: {action} (user: {user_id})")
+    async for event in remote_app.async_stream_query(
+        user_id=user_id, session_id=session_id, message=user_input
+    ):
+        logger.debug(f"Agent event: {event}")
+    logger.info(f"Agent Engine query completed for session {session_id}")
+    return f"The action '{action}' was processed by the AI agent."
+
+
+async def _execute_and_sync(payload: dict) -> None:
+    """Worker body: run the agent query, then sync state into the card."""
+    try:  # Package vs flat layout, mirroring the module-level import
+        from agent_soc_manager.tools.chatops.chat_api import update_card
+    except ImportError:
+        from chat_api import update_card
+
+    action = payload.get("action", "unknown action")
+    requester = payload.get("requester", "unknown user")
+    message_name = payload.get("message_name")
+
+    try:
+        detail = await _run_agent_query(
+            action=action,
+            session_id=payload["session_id"],
+            agent_engine_id=payload["agent_engine_id"],
+            user_id=payload.get("user_id") or "vais-query-reasoning-engine",
+        )
+        card = _outcome_card(action, requester, succeeded=True, detail=detail)
+    except Exception as e:
+        logger.error(f"Agent execution failed for action '{action}': {e}")
+        card = _outcome_card(
+            action,
+            requester,
+            succeeded=False,
+            detail=(
+                f"The agent failed to execute this action: {e}. "
+                "No state change was confirmed."
+            ),
+        )
+
+    if message_name:
+        try:
+            await update_card(message_name, card)
+        except Exception as e:
+            logger.error(f"Failed to update card {message_name}: {e}")
+
+
+@app.post("/chat/events")
+async def chat_events(request: Request, background_tasks: BackgroundTasks):
+    """Handles Google Chat interaction events for the registered Chat App."""
+    skip_verify = os.environ.get("CHATOPS_SKIP_JWT_VERIFY", "").lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+    if not skip_verify:
+        token = _bearer_token(request)
+        if not token:
+            return JSONResponse({"error": "Missing bearer token"}, status_code=401)
+        try:
+            _verify_chat_jwt(token)
+        except Exception as e:
+            logger.warning(f"Rejected Chat event with invalid JWT: {e}")
+            return JSONResponse({"error": "Invalid bearer token"}, status_code=401)
+
+    event = await request.json()
+    event_type = event.get("type")
+
+    if event_type == "ADDED_TO_SPACE":
+        return {
+            "text": (
+                "SOC Agent ChatOps connected. Approval cards posted here will "
+                "execute actions in the background when clicked."
+            )
+        }
+
+    if event_type == "MESSAGE":
+        return {
+            "text": (
+                "This app handles SOC approval cards. Interact with the "
+                "buttons on incident cards; direct messages are not processed."
+            )
+        }
+
+    if event_type == "CARD_CLICKED":
+        function, parameters = _extract_invoked_function(event)
+        if function != "execute_signed_action":
+            return _error_card(f"Unknown action function: {function}")
+
+        signed_token = parameters.get("token")
+        if not signed_token:
+            return _error_card("Missing action token. The card may be malformed.")
+
+        try:
+            payload = verify_signed_payload(signed_token)
+        except ValueError as e:
+            logger.warning(f"Rejected card click with invalid token: {e}")
+            return _error_card(
+                f"This action could not be verified and was NOT executed: {e}"
+            )
+
+        action = payload.get("action", "unknown action")
+        requester = (event.get("user") or {}).get("displayName", "unknown user")
+        message_name = (event.get("message") or {}).get("name")
+
+        task_payload = {
+            "token": signed_token,
+            "action": action,
+            "session_id": payload.get("session_id"),
+            "agent_engine_id": payload.get("agent_engine_id"),
+            "user_id": payload.get("user_id"),
+            "requester": requester,
+            "message_name": message_name,
+        }
+
+        inline = os.environ.get("CHATOPS_INLINE_EXECUTION", "").lower() in (
+            "1",
+            "true",
+            "yes",
+        )
+        if inline:
+            # Dev-only fallback: execute within this instance after responding.
+            # Cloud Run may throttle CPU post-response; use Cloud Tasks in prod.
+            background_tasks.add_task(_execute_and_sync, task_payload)
+        else:
+            try:
+                _enqueue_task(task_payload)
+            except Exception as e:
+                logger.error(f"Failed to enqueue ChatOps task: {e}")
+                return _error_card(
+                    f"Could not queue this action for execution: {e}. "
+                    "The action was NOT executed."
+                )
+
+        processing = _processing_card(action, requester)
+        return {
+            "actionResponse": {"type": "UPDATE_MESSAGE"},
+            "cardsV2": processing["cardsV2"],
+        }
+
+    logger.info(f"Ignoring unhandled Chat event type: {event_type}")
+    return {}
+
+
+@app.post("/tasks/execute")
+async def tasks_execute(request: Request):
+    """Cloud Tasks worker endpoint: executes the agent query and syncs state."""
+    skip_verify = os.environ.get("CHATOPS_SKIP_JWT_VERIFY", "").lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+    if not skip_verify:
+        token = _bearer_token(request)
+        if not token:
+            return JSONResponse({"error": "Missing bearer token"}, status_code=401)
+        try:
+            _verify_tasks_oidc(token)
+        except Exception as e:
+            logger.warning(f"Rejected worker call with invalid OIDC token: {e}")
+            return JSONResponse({"error": "Invalid bearer token"}, status_code=401)
+
+    body = await request.json()
+    signed_token = body.get("token")
+    if not signed_token:
+        return JSONResponse({"error": "Missing token"}, status_code=400)
+
+    try:
+        # Defense in depth: never trust the queue payload's IDs without
+        # re-verifying the HMAC signature that minted them.
+        payload = verify_signed_payload(signed_token)
+    except ValueError as e:
+        logger.error(f"Worker rejected invalid token: {e}")
+        return JSONResponse({"error": f"Invalid token: {e}"}, status_code=400)
+
+    body["session_id"] = payload.get("session_id")
+    body["agent_engine_id"] = payload.get("agent_engine_id")
+    body["user_id"] = payload.get("user_id")
+    body["action"] = payload.get("action", body.get("action", "unknown action"))
+
+    # Always 200 after this point: the outcome (success or failure) is
+    # reported into the card itself. Non-2xx here would trigger Cloud Tasks
+    # retries and duplicate agent executions.
+    await _execute_and_sync(body)
+    return {"status": "done"}
+
+
+@app.get("/action", response_class=HTMLResponse)
+async def legacy_action(t: str = Query(..., description="Signed action token")):
+    """Legacy openLink route: kept so in-flight signed URLs work during cutover."""
+    try:
+        payload = verify_signed_payload(t)
+        action = payload.get("action")
+        session_id = payload.get("session_id")
+        agent_engine_id = payload.get("agent_engine_id")
+        if not action or not session_id or not agent_engine_id:
+            raise ValueError("Incomplete payload inside token")
+
+        detail = await _run_agent_query(
+            action=action,
+            session_id=session_id,
+            agent_engine_id=agent_engine_id,
+            user_id=payload.get("user_id") or "vais-query-reasoning-engine",
+        )
+        return f"""
+        <html>
+            <head><title>Action Confirmed</title></head>
+            <body style="font-family: Arial; text-align: center; padding-top: 50px;">
+                <h1>Action Confirmed</h1>
+                <p>{detail}</p>
+                <p>You can close this tab and return to Google Chat.</p>
+            </body>
+        </html>
+        """
+    except Exception as e:
+        logger.error(f"Legacy action failed: {e}")
+        return HTMLResponse(
+            content=f"""
+            <html>
+                <body style="font-family: Arial; text-align: center; padding-top: 50px;">
+                    <h1>Action Failed</h1>
+                    <p>There was an error processing your request: {e}</p>
+                </body>
+            </html>
+            """,
+            status_code=500,
+        )
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=int(os.environ.get("PORT", 8080)))

--- a/agent_soc_manager/tools/chatops/chat_app_handler.py
+++ b/agent_soc_manager/tools/chatops/chat_app_handler.py
@@ -20,7 +20,9 @@ imported lazily inside functions so the module imports cleanly in offline
 unit-test environments.
 """
 
+import asyncio
 import hashlib
+import html
 import json
 import logging
 import os
@@ -44,6 +46,23 @@ CHAT_CERTS_URL = (
     "https://www.googleapis.com/service_accounts/v1/metadata/x509/"
     "chat@system.gserviceaccount.com"
 )
+
+
+# Per-turn budget for the Agent Engine query; also sizes the Cloud Tasks
+# dispatch deadline so the queue never redelivers a still-running task
+# (redelivery would double-execute an approved action).
+AGENT_QUERY_TIMEOUT = float(os.environ.get("CHATOPS_AGENT_TIMEOUT", "540"))
+
+
+def _dev_flag(name: str) -> bool:
+    """Reads a dev-only toggle, hard-blocked on Cloud Run.
+
+    CHATOPS_SKIP_JWT_VERIFY and CHATOPS_INLINE_EXECUTION must never weaken a
+    deployed service; K_SERVICE is set by Cloud Run.
+    """
+    if os.environ.get("K_SERVICE"):
+        return False
+    return os.environ.get(name, "").lower() in ("1", "true", "yes")
 
 
 def _bearer_token(request: Request) -> str | None:
@@ -82,7 +101,14 @@ def _verify_tasks_oidc(token: str) -> dict:
     audience = os.environ.get("CHATOPS_SERVICE_URL")
     if not audience:
         raise ValueError("CHATOPS_SERVICE_URL is not set on the server")
-    return id_token.verify_oauth2_token(token, AuthRequest(), audience=audience)
+    claims = id_token.verify_oauth2_token(token, AuthRequest(), audience=audience)
+
+    # Audience alone proves any Google principal minted a token for this URL;
+    # pin the caller to the configured invoker service account when set.
+    invoker = os.environ.get("CHATOPS_INVOKER_SA")
+    if invoker and claims.get("email") != invoker:
+        raise ValueError(f"OIDC caller {claims.get('email')} is not {invoker}")
+    return claims
 
 
 def _extract_invoked_function(event: dict) -> tuple[str | None, dict]:
@@ -106,6 +132,8 @@ def _extract_invoked_function(event: dict) -> tuple[str | None, dict]:
         for item in raw_action:
             if isinstance(item, dict) and "key" in item:
                 parameters[item["key"]] = item.get("value")
+    elif isinstance(raw_action, dict):
+        parameters.update(raw_action)
 
     return function, parameters
 
@@ -149,7 +177,10 @@ def _processing_card(action: str, requester: str) -> dict:
 
 
 def _outcome_card(action: str, requester: str, succeeded: bool, detail: str) -> dict:
-    status = "Confirmed" if succeeded else "Failed"
+    # "Processed", not "Confirmed": the detail carries the agent's actual
+    # response, and the agent may have declined or partially completed the
+    # action even when the query itself succeeded.
+    status = "Processed" if succeeded else "Failed"
     icon = "STAR" if succeeded else "DESCRIPTION"
     return {
         "cardsV2": [
@@ -181,8 +212,11 @@ def _outcome_card(action: str, requester: str, succeeded: bool, detail: str) -> 
 
 
 def _error_card(message: str) -> dict:
+    # NEW_MESSAGE, not UPDATE_MESSAGE: replacing the approval card on a
+    # transient failure would destroy its buttons and leave the analyst no
+    # way to retry.
     return {
-        "actionResponse": {"type": "UPDATE_MESSAGE"},
+        "actionResponse": {"type": "NEW_MESSAGE"},
         "cardsV2": [
             {
                 "cardId": "chatops-error",
@@ -237,6 +271,10 @@ def _enqueue_task(payload: dict) -> str:
             "task": {
                 "name": f"{parent}/tasks/act-{digest}",
                 "http_request": http_request,
+                # Outlive the agent-query budget: Cloud Tasks redelivers on
+                # dispatch-deadline expiry, which would double-execute an
+                # approved action.
+                "dispatch_deadline": {"seconds": int(AGENT_QUERY_TIMEOUT) + 60},
             },
         }
     )
@@ -261,12 +299,31 @@ async def _run_agent_query(
     user_input = f"USER ACTION CONFIRMED via ChatOps: {action}"
 
     logger.info(f"Querying Agent Engine for action: {action} (user: {user_id})")
+    # Capture the agent's actual response instead of fabricating success:
+    # the agent may decline or report a partial failure, and the outcome
+    # card must reflect what it said.
+    texts: list[str] = []
     async for event in remote_app.async_stream_query(
         user_id=user_id, session_id=session_id, message=user_input
     ):
         logger.debug(f"Agent event: {event}")
+        try:
+            for part in (event.get("content") or {}).get("parts") or []:
+                text = part.get("text")
+                if text:
+                    texts.append(text)
+        except AttributeError:
+            continue
     logger.info(f"Agent Engine query completed for session {session_id}")
-    return f"The action '{action}' was processed by the AI agent."
+    if texts:
+        agent_reply = texts[-1].strip()
+        if len(agent_reply) > 1500:
+            agent_reply = agent_reply[:1500] + "..."
+        return f"Agent response: {agent_reply}"
+    return (
+        f"The agent processed '{action}' but returned no text response. "
+        "Check the session transcript to confirm the outcome."
+    )
 
 
 async def _execute_and_sync(payload: dict) -> None:
@@ -281,13 +338,28 @@ async def _execute_and_sync(payload: dict) -> None:
     message_name = payload.get("message_name")
 
     try:
-        detail = await _run_agent_query(
-            action=action,
-            session_id=payload["session_id"],
-            agent_engine_id=payload["agent_engine_id"],
-            user_id=payload.get("user_id") or "vais-query-reasoning-engine",
+        detail = await asyncio.wait_for(
+            _run_agent_query(
+                action=action,
+                session_id=payload["session_id"],
+                agent_engine_id=payload["agent_engine_id"],
+                user_id=payload.get("user_id") or "vais-query-reasoning-engine",
+            ),
+            timeout=AGENT_QUERY_TIMEOUT,
         )
         card = _outcome_card(action, requester, succeeded=True, detail=detail)
+    except TimeoutError:
+        logger.error(f"Agent query timed out for action '{action}'")
+        card = _outcome_card(
+            action,
+            requester,
+            succeeded=False,
+            detail=(
+                f"The agent did not complete within {int(AGENT_QUERY_TIMEOUT)}s. "
+                "The action may still be running; check the session transcript "
+                "before retrying."
+            ),
+        )
     except Exception as e:
         logger.error(f"Agent execution failed for action '{action}': {e}")
         card = _outcome_card(
@@ -300,22 +372,35 @@ async def _execute_and_sync(payload: dict) -> None:
             ),
         )
 
-    if message_name:
+    if not message_name:
+        logger.warning(
+            f"No message_name for action '{action}'; outcome not rendered to Chat."
+        )
+        return
+
+    # The outcome must reach the human: a swallowed patch failure leaves the
+    # card on "Processing" forever for an action that already ran. Retry
+    # locally (returning non-2xx instead would re-execute the agent query).
+    for attempt in range(3):
         try:
             await update_card(message_name, card)
+            return
         except Exception as e:
-            logger.error(f"Failed to update card {message_name}: {e}")
+            logger.error(
+                f"Failed to update card {message_name} "
+                f"(attempt {attempt + 1}/3): {e}"
+            )
+            await asyncio.sleep(2 * (attempt + 1))
+    logger.error(
+        f"Giving up updating card {message_name}; outcome for '{action}' "
+        "was not rendered to Chat."
+    )
 
 
 @app.post("/chat/events")
 async def chat_events(request: Request, background_tasks: BackgroundTasks):
     """Handles Google Chat interaction events for the registered Chat App."""
-    skip_verify = os.environ.get("CHATOPS_SKIP_JWT_VERIFY", "").lower() in (
-        "1",
-        "true",
-        "yes",
-    )
-    if not skip_verify:
+    if not _dev_flag("CHATOPS_SKIP_JWT_VERIFY"):
         token = _bearer_token(request)
         if not token:
             return JSONResponse({"error": "Missing bearer token"}, status_code=401)
@@ -347,7 +432,7 @@ async def chat_events(request: Request, background_tasks: BackgroundTasks):
     if event_type == "CARD_CLICKED":
         function, parameters = _extract_invoked_function(event)
         if function != "execute_signed_action":
-            return _error_card(f"Unknown action function: {function}")
+            return _error_card(f"Unknown action function: {html.escape(str(function))}")
 
         signed_token = parameters.get("token")
         if not signed_token:
@@ -361,8 +446,23 @@ async def chat_events(request: Request, background_tasks: BackgroundTasks):
                 f"This action could not be verified and was NOT executed: {e}"
             )
 
+        user = event.get("user") or {}
+        # Optional approver allowlist: without it, any member of the space
+        # can approve state-changing actions.
+        allowlist = [
+            entry.strip().lower()
+            for entry in os.environ.get("CHATOPS_APPROVER_EMAILS", "").split(",")
+            if entry.strip()
+        ]
+        if allowlist and (user.get("email") or "").lower() not in allowlist:
+            logger.warning(f"Rejected click from unauthorized user {user.get('email')}")
+            return _error_card(
+                "You are not authorized to approve this action. It was NOT "
+                "executed. (CHATOPS_APPROVER_EMAILS)"
+            )
+
         action = payload.get("action", "unknown action")
-        requester = (event.get("user") or {}).get("displayName", "unknown user")
+        requester = html.escape(user.get("displayName", "unknown user"))
         message_name = (event.get("message") or {}).get("name")
 
         task_payload = {
@@ -375,19 +475,27 @@ async def chat_events(request: Request, background_tasks: BackgroundTasks):
             "message_name": message_name,
         }
 
-        inline = os.environ.get("CHATOPS_INLINE_EXECUTION", "").lower() in (
-            "1",
-            "true",
-            "yes",
-        )
-        if inline:
-            # Dev-only fallback: execute within this instance after responding.
-            # Cloud Run may throttle CPU post-response; use Cloud Tasks in prod.
+        if _dev_flag("CHATOPS_INLINE_EXECUTION"):
+            # Dev-only fallback (hard-blocked on Cloud Run): execute within
+            # this instance after responding.
             background_tasks.add_task(_execute_and_sync, task_payload)
         else:
             try:
-                _enqueue_task(task_payload)
+                # to_thread: the Cloud Tasks client is sync/gRPC; blocking the
+                # event loop here would stall every concurrent /chat/events
+                # request against the 30-second Chat deadline.
+                await asyncio.to_thread(_enqueue_task, task_payload)
             except Exception as e:
+                if type(e).__name__ == "AlreadyExists":
+                    # Deterministic task name collision: this exact token is
+                    # already queued or ran recently (analyst double-click).
+                    # The first click's execution stands; just re-ack.
+                    logger.info(f"Duplicate click for action '{action}'; deduped.")
+                    processing = _processing_card(action, requester)
+                    return {
+                        "actionResponse": {"type": "UPDATE_MESSAGE"},
+                        "cardsV2": processing["cardsV2"],
+                    }
                 logger.error(f"Failed to enqueue ChatOps task: {e}")
                 return _error_card(
                     f"Could not queue this action for execution: {e}. "
@@ -407,12 +515,7 @@ async def chat_events(request: Request, background_tasks: BackgroundTasks):
 @app.post("/tasks/execute")
 async def tasks_execute(request: Request):
     """Cloud Tasks worker endpoint: executes the agent query and syncs state."""
-    skip_verify = os.environ.get("CHATOPS_SKIP_JWT_VERIFY", "").lower() in (
-        "1",
-        "true",
-        "yes",
-    )
-    if not skip_verify:
+    if not _dev_flag("CHATOPS_SKIP_JWT_VERIFY"):
         token = _bearer_token(request)
         if not token:
             return JSONResponse({"error": "Missing bearer token"}, status_code=401)
@@ -432,13 +535,18 @@ async def tasks_execute(request: Request):
         # re-verifying the HMAC signature that minted them.
         payload = verify_signed_payload(signed_token)
     except ValueError as e:
-        logger.error(f"Worker rejected invalid token: {e}")
-        return JSONResponse({"error": f"Invalid token: {e}"}, status_code=400)
+        # 200, not 4xx: after a secret rotation every queued token fails
+        # verification, and a non-2xx would make Cloud Tasks retry each one
+        # to max attempts. The task is terminally dropped either way.
+        logger.error(f"Worker dropped task with invalid token: {e}")
+        return {"status": "dropped", "error": f"Invalid token: {e}"}
 
     body["session_id"] = payload.get("session_id")
     body["agent_engine_id"] = payload.get("agent_engine_id")
     body["user_id"] = payload.get("user_id")
-    body["action"] = payload.get("action", body.get("action", "unknown action"))
+    # Only token-verified fields drive execution; the queue body's action is
+    # never trusted.
+    body["action"] = payload.get("action", "unknown action")
 
     # Always 200 after this point: the outcome (success or failure) is
     # reported into the card itself. Non-2xx here would trigger Cloud Tasks
@@ -469,7 +577,7 @@ async def legacy_action(t: str = Query(..., description="Signed action token")):
             <head><title>Action Confirmed</title></head>
             <body style="font-family: Arial; text-align: center; padding-top: 50px;">
                 <h1>Action Confirmed</h1>
-                <p>{detail}</p>
+                <p>{html.escape(detail)}</p>
                 <p>You can close this tab and return to Google Chat.</p>
             </body>
         </html>
@@ -481,7 +589,7 @@ async def legacy_action(t: str = Query(..., description="Signed action token")):
             <html>
                 <body style="font-family: Arial; text-align: center; padding-top: 50px;">
                     <h1>Action Failed</h1>
-                    <p>There was an error processing your request: {e}</p>
+                    <p>There was an error processing your request: {html.escape(str(e))}</p>
                 </body>
             </html>
             """,

--- a/agent_soc_manager/tools/chatops/cloud_run_deploy.sh
+++ b/agent_soc_manager/tools/chatops/cloud_run_deploy.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
-# Deploy ChatOps Webhook Handler to Google Cloud Run
+# Deploy ChatOps Chat App Handler to Google Cloud Run
+#
+# Prefer the managed path, which resolves GCP_PROJECT_NUMBER and validates
+# configuration first:
+#     python manage.py chatops deploy-app
+# This script is the minimal equivalent for CI or manual use.
 
 # Load environment variables from .env
 if [ -f .env ]; then
@@ -7,13 +12,20 @@ if [ -f .env ]; then
 fi
 
 # Configuration
-SERVICE_NAME="chatops-webhook"
+SERVICE_NAME="chatops-chat-app"
 REGION=${GCP_LOCATION:-us-central1}
 PROJECT_ID=${GCP_PROJECT_ID}
 
 # Ensure project and region are set
 if [ -z "$PROJECT_ID" ]; then
     echo "ERROR: GCP_PROJECT_ID not set"
+    exit 1
+fi
+
+# The handler fails closed without a real secret (security.py); catch the
+# misconfiguration here instead of shipping a broken service.
+if [ -z "$CHRONICLE_CHATOPS_SECRET" ]; then
+    echo "ERROR: CHRONICLE_CHATOPS_SECRET not set (empty secret would disable HMAC integrity)"
     exit 1
 fi
 
@@ -26,4 +38,4 @@ gcloud run deploy $SERVICE_NAME \
     --region=$REGION \
     --source=agent_soc_manager/tools/chatops/ \
     --allow-unauthenticated \
-    --set-env-vars "CHRONICLE_CHATOPS_SECRET=$CHRONICLE_CHATOPS_SECRET,AGENT_ENGINE_RESOURCE_NAME=$AGENT_ENGINE_RESOURCE_NAME,GCP_PROJECT_ID=$GCP_PROJECT_ID,GCP_LOCATION=$GCP_LOCATION"
+    --set-env-vars "CHRONICLE_CHATOPS_SECRET=$CHRONICLE_CHATOPS_SECRET,AGENT_ENGINE_RESOURCE_NAME=$AGENT_ENGINE_RESOURCE_NAME,GCP_PROJECT_ID=$GCP_PROJECT_ID,GCP_LOCATION=$GCP_LOCATION,GCP_PROJECT_NUMBER=$GCP_PROJECT_NUMBER,CHATOPS_SERVICE_URL=$CHATOPS_SERVICE_URL,CHATOPS_TASKS_QUEUE=${CHATOPS_TASKS_QUEUE:-chatops-actions},CHATOPS_TASKS_LOCATION=${CHATOPS_TASKS_LOCATION:-$REGION},CHATOPS_INVOKER_SA=$CHATOPS_INVOKER_SA"

--- a/agent_soc_manager/tools/chatops/requirements.txt
+++ b/agent_soc_manager/tools/chatops/requirements.txt
@@ -5,3 +5,5 @@ google-cloud-aiplatform
 python-dotenv
 pyjwt
 cryptography
+google-auth
+google-cloud-tasks

--- a/agent_soc_manager/tools/chatops/security.py
+++ b/agent_soc_manager/tools/chatops/security.py
@@ -18,7 +18,16 @@ def _get_secret():
 
     secret = os.getenv("CHRONICLE_CHATOPS_SECRET")
     if not secret:
-        # Fallback for development, should be explicitly set in production
+        # Fail closed on Cloud Run (K_SERVICE set): signing with the public
+        # fallback would let anyone mint valid approval tokens. An unset
+        # shell var in a deploy script must not silently weaken HMAC.
+        if os.getenv("K_SERVICE"):
+            raise ValueError(
+                "CHRONICLE_CHATOPS_SECRET is not set; refusing to sign or "
+                "verify ChatOps tokens with the development fallback secret "
+                "in a deployed service."
+            )
+        # Fallback for local development only
         return "development_fallback_secret_not_for_production"
     return secret
 

--- a/agent_soc_manager/tools/chatops/test_chat_app.py
+++ b/agent_soc_manager/tools/chatops/test_chat_app.py
@@ -237,7 +237,7 @@ def test_worker_executes_and_syncs_card():
     message_name, card = updates[0]
     assert message_name == "spaces/S/messages/M"
     card_text = str(card)
-    assert "Confirmed" in card_text
+    assert "Processed" in card_text
     assert "Approve Block IP" in card_text
     print("test_worker_executes_and_syncs_card passed")
 
@@ -271,11 +271,98 @@ def test_worker_failure_syncs_honest_failure():
     print("test_worker_failure_syncs_honest_failure passed")
 
 
-def test_worker_invalid_token_rejected():
+def test_worker_invalid_token_dropped():
     client = TestClient(chat_app_handler.app)
     response = client.post("/tasks/execute", json={"token": "bogus.token"})
-    assert response.status_code == 400
-    print("test_worker_invalid_token_rejected passed")
+    # 200 with a dropped status: a 4xx would make Cloud Tasks retry every
+    # queued task to max attempts after a secret rotation.
+    assert response.status_code == 200
+    assert response.json()["status"] == "dropped"
+    print("test_worker_invalid_token_dropped passed")
+
+
+def test_approver_allowlist_rejects_unlisted_user():
+    token = _signed_token("Approve Block IP")
+    os.environ["CHATOPS_APPROVER_EMAILS"] = "lead@example.com"
+    try:
+        client = TestClient(chat_app_handler.app)
+        event = {
+            "type": "CARD_CLICKED",
+            "common": {
+                "invokedFunction": "execute_signed_action",
+                "parameters": {"token": token},
+            },
+            "user": {"displayName": "Mallory", "email": "mallory@example.com"},
+            "message": {"name": "spaces/S/messages/M"},
+        }
+        response = client.post("/chat/events", json=event)
+        assert response.status_code == 200
+        body = response.json()
+        assert "not authorized" in str(body)
+        # Error responses post a new message so the approval card's buttons
+        # survive for an authorized approver.
+        assert body["actionResponse"]["type"] == "NEW_MESSAGE"
+    finally:
+        os.environ.pop("CHATOPS_APPROVER_EMAILS", None)
+    print("test_approver_allowlist_rejects_unlisted_user passed")
+
+
+def test_double_click_dedupes_to_processing_card():
+    token = _signed_token("Approve Isolate Host")
+
+    class AlreadyExists(Exception):
+        pass
+
+    def raise_already_exists(payload):
+        raise AlreadyExists("task exists")
+
+    chat_app_handler._enqueue_task = raise_already_exists
+    client = TestClient(chat_app_handler.app)
+    event = {
+        "type": "CARD_CLICKED",
+        "common": {
+            "invokedFunction": "execute_signed_action",
+            "parameters": {"token": token},
+        },
+        "user": {"displayName": "Dana Analyst"},
+        "message": {"name": "spaces/S/messages/M"},
+    }
+    response = client.post("/chat/events", json=event)
+    assert response.status_code == 200
+    body = response.json()
+    # The duplicate click is acked with the processing card, not an error:
+    # the first click's execution stands.
+    assert body["actionResponse"]["type"] == "UPDATE_MESSAGE"
+    assert "Processing" in str(body["cardsV2"])
+    print("test_double_click_dedupes_to_processing_card passed")
+
+
+def test_secret_fails_closed_on_cloud_run():
+    from agent_soc_manager.tools.chatops import security as security_mod
+
+    real_secret = os.environ.pop("CHRONICLE_CHATOPS_SECRET")
+    os.environ["K_SERVICE"] = "chatops-chat-app"
+    try:
+        try:
+            security_mod._get_secret()
+            raise AssertionError("expected ValueError for missing secret")
+        except ValueError:
+            pass
+    finally:
+        os.environ.pop("K_SERVICE", None)
+        os.environ["CHRONICLE_CHATOPS_SECRET"] = real_secret
+    print("test_secret_fails_closed_on_cloud_run passed")
+
+
+def test_dev_flags_blocked_on_cloud_run():
+    os.environ["K_SERVICE"] = "chatops-chat-app"
+    try:
+        assert chat_app_handler._dev_flag("CHATOPS_SKIP_JWT_VERIFY") is False
+        assert chat_app_handler._dev_flag("CHATOPS_INLINE_EXECUTION") is False
+    finally:
+        os.environ.pop("K_SERVICE", None)
+    assert chat_app_handler._dev_flag("CHATOPS_SKIP_JWT_VERIFY") is True
+    print("test_dev_flags_blocked_on_cloud_run passed")
 
 
 def test_legacy_action_route_present():
@@ -322,7 +409,11 @@ if __name__ == "__main__":
     test_events_missing_bearer_rejected_when_verifying()
     test_worker_executes_and_syncs_card()
     test_worker_failure_syncs_honest_failure()
-    test_worker_invalid_token_rejected()
+    test_worker_invalid_token_dropped()
+    test_approver_allowlist_rejects_unlisted_user()
+    test_double_click_dedupes_to_processing_card()
+    test_secret_fails_closed_on_cloud_run()
+    test_dev_flags_blocked_on_cloud_run()
     test_legacy_action_route_present()
     test_dispatch_dual_mode_routing()
     print("\nAll chat_app tests passed.")

--- a/agent_soc_manager/tools/chatops/test_chat_app.py
+++ b/agent_soc_manager/tools/chatops/test_chat_app.py
@@ -1,0 +1,328 @@
+"""Offline unit tests for the native Chat App migration (issue #62).
+
+Runs without GCP access: JWT verification is bypassed via
+CHATOPS_SKIP_JWT_VERIFY, Cloud Tasks enqueue and the Agent Engine query are
+monkeypatched, and the Chat REST API is never called.
+
+Run directly:
+    .venv/bin/python agent_soc_manager/tools/chatops/test_chat_app.py
+"""
+
+import asyncio
+import copy
+import os
+import sys
+import types
+from pathlib import Path
+
+
+os.environ["CHATOPS_SKIP_JWT_VERIFY"] = "true"
+os.environ["CHRONICLE_CHATOPS_SECRET"] = "unit-test-secret"
+os.environ["CHATOPS_BASE_URL"] = "https://handler.example.com/chatops"
+
+# Offline bootstrap: agent_soc_manager/__init__.py imports the full ADK agent
+# stack, which is not installed in a lightweight test environment. Register
+# bare parent packages so submodules import without executing that __init__,
+# and stub the one ADK symbol chatops_tools needs.
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_PKG_ROOT = _REPO_ROOT / "agent_soc_manager"
+for _name, _path in (
+    ("agent_soc_manager", _PKG_ROOT),
+    ("agent_soc_manager.tools", _PKG_ROOT / "tools"),
+):
+    if _name not in sys.modules:
+        _mod = types.ModuleType(_name)
+        _mod.__path__ = [str(_path)]
+        sys.modules[_name] = _mod
+
+if "google.adk.agents.context" not in sys.modules:
+    _adk = types.ModuleType("google.adk")
+    _adk_agents = types.ModuleType("google.adk.agents")
+    _adk_context = types.ModuleType("google.adk.agents.context")
+    _adk_context.Context = object
+    sys.modules.setdefault("google.adk", _adk)
+    sys.modules.setdefault("google.adk.agents", _adk_agents)
+    sys.modules.setdefault("google.adk.agents.context", _adk_context)
+
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from fastapi.testclient import TestClient
+
+from agent_soc_manager.tools.chatops import chat_app_handler
+from agent_soc_manager.tools.chatops.chat_api import (
+    ACTION_FUNCTION,
+    convert_openlink_to_action,
+)
+from agent_soc_manager.tools.chatops.security import generate_signed_payload
+
+
+def _signed_token(action: str = "Approve Block IP") -> str:
+    return generate_signed_payload(
+        {
+            "action": action,
+            "session_id": "sess-1",
+            "agent_engine_id": "projects/p/locations/l/reasoningEngines/1",
+            "user_id": "analyst@example.com",
+        }
+    )
+
+
+def _card_with_buttons(action_url: str) -> dict:
+    return {
+        "cardsV2": [
+            {
+                "cardId": "test",
+                "card": {
+                    "sections": [
+                        {
+                            "widgets": [
+                                {
+                                    "buttonList": {
+                                        "buttons": [
+                                            {
+                                                "text": "Approve",
+                                                "onClick": {
+                                                    "openLink": {"url": action_url}
+                                                },
+                                            },
+                                            {
+                                                "text": "View in Chronicle",
+                                                "onClick": {
+                                                    "openLink": {
+                                                        "url": "https://chronicle.example.com/case/1"
+                                                    }
+                                                },
+                                            },
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+            }
+        ]
+    }
+
+
+def test_transform():
+    token = _signed_token()
+    url = f"https://handler.example.com/chatops/action?t={token}"
+    card = _card_with_buttons(url)
+    original = copy.deepcopy(card)
+
+    converted = convert_openlink_to_action(card)
+
+    # Input is not mutated
+    assert card == original
+
+    buttons = converted["cardsV2"][0]["card"]["sections"][0]["widgets"][0][
+        "buttonList"
+    ]["buttons"]
+
+    # Signed action button becomes a native action with the token parameter
+    approve = buttons[0]
+    assert "openLink" not in approve["onClick"]
+    assert approve["onClick"]["action"]["function"] == ACTION_FUNCTION
+    assert approve["onClick"]["action"]["parameters"] == [
+        {"key": "token", "value": token}
+    ]
+
+    # Informational link button is untouched
+    chronicle = buttons[1]
+    assert chronicle["onClick"]["openLink"]["url"] == (
+        "https://chronicle.example.com/case/1"
+    )
+
+    # Idempotent: converting again changes nothing
+    assert convert_openlink_to_action(converted) == converted
+    print("test_transform passed")
+
+
+def test_events_card_clicked_enqueues_and_acks():
+    token = _signed_token("Approve Isolate Host")
+    enqueued = []
+    chat_app_handler._enqueue_task = lambda payload: enqueued.append(payload) or "task"
+
+    client = TestClient(chat_app_handler.app)
+    event = {
+        "type": "CARD_CLICKED",
+        "common": {
+            "invokedFunction": "execute_signed_action",
+            "parameters": {"token": token},
+        },
+        "user": {"displayName": "Dana Analyst"},
+        "message": {"name": "spaces/S/messages/M"},
+    }
+    response = client.post("/chat/events", json=event)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["actionResponse"]["type"] == "UPDATE_MESSAGE"
+    card_text = str(body["cardsV2"])
+    assert "Processing" in card_text
+    assert "Approve Isolate Host" in card_text
+    assert "Dana Analyst" in card_text
+
+    assert len(enqueued) == 1
+    assert enqueued[0]["token"] == token
+    assert enqueued[0]["message_name"] == "spaces/S/messages/M"
+    print("test_events_card_clicked_enqueues_and_acks passed")
+
+
+def test_events_invalid_token_rejected():
+    client = TestClient(chat_app_handler.app)
+    event = {
+        "type": "CARD_CLICKED",
+        "common": {
+            "invokedFunction": "execute_signed_action",
+            "parameters": {"token": "bogus.token"},
+        },
+    }
+    response = client.post("/chat/events", json=event)
+    assert response.status_code == 200
+    assert "NOT executed" in str(response.json())
+    print("test_events_invalid_token_rejected passed")
+
+
+def test_events_message_and_added_to_space():
+    client = TestClient(chat_app_handler.app)
+    for event_type in ("MESSAGE", "ADDED_TO_SPACE"):
+        response = client.post("/chat/events", json={"type": event_type})
+        assert response.status_code == 200
+        assert "text" in response.json()
+    print("test_events_message_and_added_to_space passed")
+
+
+def test_events_missing_bearer_rejected_when_verifying():
+    os.environ["CHATOPS_SKIP_JWT_VERIFY"] = "false"
+    try:
+        client = TestClient(chat_app_handler.app)
+        response = client.post("/chat/events", json={"type": "MESSAGE"})
+        assert response.status_code == 401
+    finally:
+        os.environ["CHATOPS_SKIP_JWT_VERIFY"] = "true"
+    print("test_events_missing_bearer_rejected_when_verifying passed")
+
+
+def test_worker_executes_and_syncs_card():
+    token = _signed_token("Approve Block IP")
+    updates = []
+
+    async def fake_query(action, session_id, agent_engine_id, user_id):
+        assert session_id == "sess-1"
+        assert agent_engine_id.endswith("reasoningEngines/1")
+        return f"The action '{action}' was processed by the AI agent."
+
+    async def fake_update(message_name, card):
+        updates.append((message_name, card))
+
+    chat_app_handler._run_agent_query = fake_query
+    import agent_soc_manager.tools.chatops.chat_api as chat_api_mod
+
+    chat_api_mod.update_card = fake_update
+
+    client = TestClient(chat_app_handler.app)
+    response = client.post(
+        "/tasks/execute",
+        json={
+            "token": token,
+            "requester": "Dana Analyst",
+            "message_name": "spaces/S/messages/M",
+        },
+    )
+    assert response.status_code == 200
+    assert len(updates) == 1
+    message_name, card = updates[0]
+    assert message_name == "spaces/S/messages/M"
+    card_text = str(card)
+    assert "Confirmed" in card_text
+    assert "Approve Block IP" in card_text
+    print("test_worker_executes_and_syncs_card passed")
+
+
+def test_worker_failure_syncs_honest_failure():
+    token = _signed_token("Approve Wipe Host")
+    updates = []
+
+    async def failing_query(action, session_id, agent_engine_id, user_id):
+        raise RuntimeError("Agent Engine unavailable")
+
+    async def fake_update(message_name, card):
+        updates.append(card)
+
+    chat_app_handler._run_agent_query = failing_query
+    import agent_soc_manager.tools.chatops.chat_api as chat_api_mod
+
+    chat_api_mod.update_card = fake_update
+
+    client = TestClient(chat_app_handler.app)
+    response = client.post(
+        "/tasks/execute",
+        json={"token": token, "message_name": "spaces/S/messages/M"},
+    )
+    # 200 by design: retrying would duplicate agent executions; the failure
+    # is reported into the card instead.
+    assert response.status_code == 200
+    card_text = str(updates[0])
+    assert "Failed" in card_text
+    assert "No state change was confirmed" in card_text
+    print("test_worker_failure_syncs_honest_failure passed")
+
+
+def test_worker_invalid_token_rejected():
+    client = TestClient(chat_app_handler.app)
+    response = client.post("/tasks/execute", json={"token": "bogus.token"})
+    assert response.status_code == 400
+    print("test_worker_invalid_token_rejected passed")
+
+
+def test_legacy_action_route_present():
+    client = TestClient(chat_app_handler.app)
+    response = client.get("/action", params={"t": "bogus.token"})
+    # Invalid token yields the legacy HTML failure page, proving the route
+    # is served by the new handler app.
+    assert response.status_code == 500
+    assert "Action Failed" in response.text
+    print("test_legacy_action_route_present passed")
+
+
+def test_dispatch_dual_mode_routing():
+    from agent_soc_manager.tools import chatops_tools
+
+    # chat_app mode without CHAT_SPACE: explicit error, no fabricated success
+    os.environ["CHATOPS_MODE"] = "chat_app"
+    os.environ.pop("CHAT_SPACE", None)
+    result = asyncio.run(chatops_tools.send_raw_card({"cardsV2": []}))
+    assert result.startswith("Error")
+    assert "CHAT_SPACE" in result
+
+    # webhook default: unchanged error path when WEBHOOK_URL is unset
+    os.environ["CHATOPS_MODE"] = "webhook"
+    os.environ.pop("WEBHOOK_URL", None)
+    result = asyncio.run(chatops_tools.send_raw_card({"cardsV2": []}))
+    assert "WEBHOOK_URL" in result
+
+    # send_chatops_card routes through the same seam
+    os.environ["CHATOPS_MODE"] = "chat_app"
+    result = asyncio.run(
+        chatops_tools.send_chatops_card(title="T", subtitle="S", sections=[])
+    )
+    assert "CHAT_SPACE" in result
+    os.environ.pop("CHATOPS_MODE", None)
+    print("test_dispatch_dual_mode_routing passed")
+
+
+if __name__ == "__main__":
+    test_transform()
+    test_events_card_clicked_enqueues_and_acks()
+    test_events_invalid_token_rejected()
+    test_events_message_and_added_to_space()
+    test_events_missing_bearer_rejected_when_verifying()
+    test_worker_executes_and_syncs_card()
+    test_worker_failure_syncs_honest_failure()
+    test_worker_invalid_token_rejected()
+    test_legacy_action_route_present()
+    test_dispatch_dual_mode_routing()
+    print("\nAll chat_app tests passed.")

--- a/agent_soc_manager/tools/chatops_tools.py
+++ b/agent_soc_manager/tools/chatops_tools.py
@@ -16,6 +16,48 @@ CHATOPS_HTTP_TIMEOUT = float(os.environ.get("CHATOPS_HTTP_TIMEOUT", "30"))
 logger = logging.getLogger(__name__)
 
 
+def _chat_app_mode() -> bool:
+    """True when ChatOps should post as the registered Chat App (issue #62).
+
+    Native app posting enables background button actions (no browser tab).
+    Webhook mode remains the default until CHATOPS_MODE=chat_app is set.
+    """
+    return os.environ.get("CHATOPS_MODE", "webhook").strip().lower() == "chat_app"
+
+
+async def _send_via_chat_app(payload: dict) -> str:
+    """Posts a card as the Chat App with action buttons converted in place.
+
+    The one-seam migration: every card template's signed openLink buttons
+    are rewritten to native onClick.action payloads here, so no template
+    needs editing and clicks execute in the background.
+    """
+    from agent_soc_manager.tools.chatops.chat_api import (
+        convert_openlink_to_action,
+        post_card_as_app,
+    )
+
+    space = os.environ.get("CHAT_SPACE")
+    if not space:
+        logger.error("CHATOPS_MODE=chat_app but CHAT_SPACE is not set.")
+        return (
+            "Error: CHATOPS_MODE=chat_app requires CHAT_SPACE (e.g. "
+            "'spaces/AAAA1234'). No message was sent to a human analyst."
+        )
+
+    try:
+        converted = convert_openlink_to_action(payload)
+        message_name = await post_card_as_app(space, converted)
+        logger.info(f"ChatOps card posted as Chat App: {message_name}")
+        return f"Successfully sent ChatOps card as Chat App. (Message: {message_name})"
+    except Exception as e:
+        logger.error(f"Failed to post ChatOps card as Chat App: {e}")
+        return (
+            f"Error sending ChatOps card via Chat App: {e}. "
+            "No human analyst was notified."
+        )
+
+
 def _get_context_ids(
     ctx: Context,
 ) -> tuple[str | None, str | None, str | None]:
@@ -88,7 +130,13 @@ def _get_context_ids(
 async def send_raw_card(payload: dict) -> str:
     """
     Sends a complete raw JSON card payload to the configured Google Chat webhook asynchronously.
+
+    When CHATOPS_MODE=chat_app, posts as the registered Chat App instead so
+    card buttons execute in the background (issue #62).
     """
+    if _chat_app_mode():
+        return await _send_via_chat_app(payload)
+
     webhook_url = os.environ.get("WEBHOOK_URL")
     if not webhook_url:
         logger.error("WEBHOOK_URL environment variable is not set.")
@@ -237,12 +285,7 @@ async def send_chatops_card(
         card_id: Unique ID for the card (optional).
         image_url: URL for the header icon (optional).
     """
-    webhook_url = os.environ.get("WEBHOOK_URL")
-    if not webhook_url:
-        logger.error("WEBHOOK_URL environment variable is not set.")
-        return "Error: WEBHOOK_URL environment variable is not set. Please configure it in .env."
-
-    payload = {
+    payload_for_chat_app = {
         "cardsV2": [
             {
                 "cardId": card_id,
@@ -258,6 +301,15 @@ async def send_chatops_card(
             }
         ]
     }
+    if _chat_app_mode():
+        return await _send_via_chat_app(payload_for_chat_app)
+
+    webhook_url = os.environ.get("WEBHOOK_URL")
+    if not webhook_url:
+        logger.error("WEBHOOK_URL environment variable is not set.")
+        return "Error: WEBHOOK_URL environment variable is not set. Please configure it in .env."
+
+    payload = payload_for_chat_app
 
     try:
         async with httpx.AsyncClient(timeout=CHATOPS_HTTP_TIMEOUT) as client:

--- a/docs/chatops_chat_app.md
+++ b/docs/chatops_chat_app.md
@@ -81,12 +81,42 @@ links (for example "View in Chronicle") are left as `openLink`.
 ### Failure semantics
 
 - If the queue is unavailable, the click is rejected with an explicit
-  "action was NOT executed" card. Delivery success is never fabricated.
-- If the agent query fails, the card is updated with the failure and the
-  worker still returns HTTP 200 -- retrying would duplicate agent
-  executions; the failure is surfaced to the human instead.
+  "action was NOT executed" message posted alongside the card (the approval
+  card and its buttons survive for a retry). Delivery success is never
+  fabricated.
+- The outcome card renders the agent's actual response ("Action
+  Processed"), not a fabricated confirmation -- the agent may decline or
+  report partial failure, and the human sees what it said.
+- The agent query is bounded by `CHATOPS_AGENT_TIMEOUT` (default 540s), and
+  the Cloud Tasks dispatch deadline is set above it so the queue never
+  redelivers a still-running task (redelivery would double-execute).
+- If the agent query fails or times out, the card is updated with the
+  failure and the worker still returns HTTP 200 -- retrying would duplicate
+  agent executions; the failure is surfaced to the human instead. Card
+  updates themselves retry three times before giving up loudly in logs.
 - Analyst double-clicks dedupe via deterministic Cloud Tasks task names
-  derived from the token hash.
+  derived from the token hash; the duplicate click re-acks with the
+  Processing card.
+- Tokens that fail HMAC verification at the worker are dropped with HTTP
+  200 (a 4xx would retry every queued task to max attempts after a secret
+  rotation).
+
+### Security posture
+
+- Interaction events require a valid Google-issued JWT; the worker requires
+  a Cloud Tasks OIDC token, pinned to `CHATOPS_INVOKER_SA` when set.
+- The HMAC layer fails closed on Cloud Run: a missing
+  `CHRONICLE_CHATOPS_SECRET` raises instead of falling back to the public
+  development secret.
+- `CHATOPS_SKIP_JWT_VERIFY` and `CHATOPS_INLINE_EXECUTION` are hard-blocked
+  when running on Cloud Run (`K_SERVICE` present).
+- `CHATOPS_APPROVER_EMAILS` (optional, comma-separated) restricts who may
+  click Approve/Deny; unset means any member of the space can approve.
+- User-supplied event text (display names, function names) is HTML-escaped
+  before rendering into cards or the legacy HTML pages.
+- Known residual gaps tracked for follow-up: legacy `/action` tokens are
+  replayable within their 1 hour TTL (no consumed-token store), and tokens
+  are not bound to a specific space or message.
 
 ## Setup
 

--- a/docs/chatops_chat_app.md
+++ b/docs/chatops_chat_app.md
@@ -1,0 +1,159 @@
+---
+type: "Documentation"
+title: "ChatOps Native Chat App Migration"
+description: "Architecture and setup for the native Google Chat App ChatOps integration: background action execution, Cloud Tasks decoupling, and in-card state synchronization."
+resource: "docs/chatops_chat_app.md"
+timestamp: "2026-08-01T23:30:00Z"
+provenance:
+  source_type: "generative_ai"
+  source_tool: "Claude Code"
+  timestamp: "2026-08-01T23:30:00Z"
+---
+
+# ChatOps Native Chat App Migration
+
+This document covers the migration from Google Chat incoming webhooks to a
+registered Google Chat App (issue #62), which delivers three UX and
+reliability upgrades:
+
+1. **Background execution (zero-tab UX).** Card buttons use native
+   `onClick.action` payloads. Clicking Approve or Deny executes the action
+   in the background instead of opening an empty browser tab.
+2. **Decoupled latency.** Google Chat requires a response to interaction
+   events within 30 seconds, but Agent Engine queries can take minutes. A
+   Cloud Tasks queue separates the immediate acknowledgment from the agent
+   execution.
+3. **State synchronization.** The original card updates itself: first to a
+   "Processing" state on click, then to the confirmed (or honestly failed)
+   outcome once the agent completes.
+
+## Why a Chat App is required
+
+Messages posted through an incoming webhook cannot carry `onClick.action`
+buttons -- Google Chat only routes `CARD_CLICKED` interaction events to the
+app that posted the message. That structural constraint is why the legacy
+flow used `openLink` buttons pointing at a signed URL, and why fixing the
+empty-tab UX requires migrating message posting to the Chat REST API.
+
+## Architecture
+
+```
+Agent Engine (chatops_tools.py)
+    |  CHATOPS_MODE=chat_app
+    v
+chat_api.post_card_as_app()  --- Chat REST API --->  Google Chat space
+    (openLink buttons auto-converted to action buttons at this seam)
+
+Analyst clicks Approve
+    |
+    v
+POST /chat/events  (Cloud Run: chat_app_handler.py)
+    1. Verify Google-issued bearer JWT (issuer chat@system.gserviceaccount.com,
+       audience GCP_PROJECT_NUMBER)
+    2. HMAC-verify the signed action token (security.py, defense in depth)
+    3. Enqueue Cloud Tasks task (task name = token hash, so double-clicks dedupe)
+    4. Return an in-place "Processing" card update -- well inside 30 seconds
+    |
+    v
+Cloud Tasks queue (chatops-actions)
+    |  OIDC-authenticated HTTP push
+    v
+POST /tasks/execute  (same Cloud Run service)
+    1. Verify the Cloud Tasks OIDC token (audience CHATOPS_SERVICE_URL)
+    2. Re-verify the HMAC token
+    3. Run the Agent Engine query (may take minutes)
+    4. PATCH the original card with the confirmed or failed outcome
+```
+
+The legacy `GET /action` route is still served by the new handler so signed
+`openLink` URLs generated before the cutover (1 hour TTL) keep working.
+
+### The one-seam template migration
+
+All 55 card templates build their buttons through
+`card_client.generate_action_url()`, producing
+`onClick: {openLink: {url: <base>/action?t=<signed token>}}`. In `chat_app`
+mode, `chat_api.convert_openlink_to_action()` rewrites exactly those buttons
+into native action payloads at dispatch time
+(`chatops_tools.send_raw_card`). No template file changes; informational
+links (for example "View in Chronicle") are left as `openLink`.
+
+### Failure semantics
+
+- If the queue is unavailable, the click is rejected with an explicit
+  "action was NOT executed" card. Delivery success is never fabricated.
+- If the agent query fails, the card is updated with the failure and the
+  worker still returns HTTP 200 -- retrying would duplicate agent
+  executions; the failure is surfaced to the human instead.
+- Analyst double-clicks dedupe via deterministic Cloud Tasks task names
+  derived from the token hash.
+
+## Setup
+
+### 1. Deploy the handler and queue
+
+```bash
+just chatops-deploy-app      # Cloud Run: /chat/events, /tasks/execute, /action
+just chatops-create-queue    # Cloud Tasks queue (default: chatops-actions)
+```
+
+On the first deploy, copy the service URL into `.env` as
+`CHATOPS_SERVICE_URL` and redeploy so the worker's OIDC audience matches.
+
+### 2. Register the Chat App (manual, one-time)
+
+```bash
+just chatops-registration-guide
+```
+
+This prints the console steps: enable `chat.googleapis.com`, configure the
+app's interactive features with the HTTP endpoint URL
+`<CHATOPS_SERVICE_URL>/chat/events`, set visibility, and add the app to the
+SOC space.
+
+### 3. Configure the environment
+
+```bash
+# .env
+CHATOPS_MODE=chat_app
+CHAT_SPACE=spaces/<space id>
+GCP_PROJECT_NUMBER=<project number>
+CHATOPS_SERVICE_URL=https://<service>.a.run.app
+CHATOPS_INVOKER_SA=<sa with run.invoker on the handler>
+```
+
+Validate with:
+
+```bash
+just chatops-verify
+```
+
+Then redeploy the agents so the new mode reaches Agent Engine.
+
+### Migration and rollback
+
+`CHATOPS_MODE` defaults to `webhook`; the legacy path is untouched until you
+opt in. Rolling back is removing `CHATOPS_MODE=chat_app` from the
+environment and redeploying -- no code changes involved.
+
+### IAM summary
+
+| Identity | Role | Why |
+|---|---|---|
+| Cloud Run service SA | `roles/cloudtasks.enqueuer` | enqueue action tasks |
+| Cloud Run service SA | `chat.bot` scope (app auth) | patch cards as the app |
+| `CHATOPS_INVOKER_SA` | `roles/run.invoker` on the handler | Cloud Tasks push auth |
+| Agent Engine SA | `chat.bot` scope (app auth) | post cards as the app |
+
+App auth requires the Chat App to be registered in the same GCP project as
+the identities above (or `GOOGLE_APPLICATION_CREDENTIALS` pointing at the
+app project's service account key).
+
+## Development
+
+- `CHATOPS_INLINE_EXECUTION=true` executes actions with FastAPI background
+  tasks instead of Cloud Tasks (dev only: Cloud Run may throttle CPU after
+  the response).
+- `CHATOPS_SKIP_JWT_VERIFY=true` disables bearer verification for local
+  testing (never in production).
+- Offline unit tests: `python agent_soc_manager/tools/chatops/test_chat_app.py`

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -236,3 +236,25 @@ just harvest-detections                  # Harvest active alerting detections
 python manage.py harvest investigations  # Harvest security cases
 python manage.py harvest detections      # Harvest alerting detections
 ```
+
+## 10. ChatOps (Google Chat)
+
+Manage the ChatOps card library and the native Chat App integration
+(background button actions -- see [chatops_chat_app.md](chatops_chat_app.md)):
+
+### using justfile:
+```bash
+just chatops-list                       # List available card templates
+just chatops-test <card>                # Send a card to test delivery
+just chatops-deploy-app                 # Deploy the Chat App handler to Cloud Run
+just chatops-create-queue               # Create the Cloud Tasks action queue
+just chatops-registration-guide         # Print one-time Chat App registration steps
+just chatops-verify                     # Validate env for the configured mode
+```
+
+### using Python CLI:
+```bash
+python manage.py chatops list
+python manage.py chatops deploy-app
+python manage.py chatops verify-config
+```

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -75,6 +75,13 @@ These variables are required to link your agent with the Gemini Enterprise Agent
 - `OAUTH_AUTH_URI`: The OAuth authorization URI.
 - `OAUTH_TOKEN_URI`: The OAuth token exchange URI.
 
+### Stage 5: ChatOps (optional)
+Human-in-the-loop approval cards in Google Chat. Webhook mode needs only
+`WEBHOOK_URL` and `CHRONICLE_CHATOPS_SECRET`. For background button actions
+(no browser tab), set `CHATOPS_MODE=chat_app` and follow the registration
+steps in [chatops_chat_app.md](chatops_chat_app.md); validate with
+`just chatops-verify`.
+
 ## Service Accounts & IAM
 
 Four distinct identities interact with this platform. Granting the wrong set to the wrong identity is the most common deployment failure, so they are documented separately. Official references: [Agent Engine set-up: identity and permissions](https://docs.cloud.google.com/agent-builder/agent-engine/set-up#identity-and-permissions) and [custom service accounts](https://cloud.google.com/agent-builder/agent-engine/set-up#custom-service-account).

--- a/installation_scripts/manage_chat_ops.py
+++ b/installation_scripts/manage_chat_ops.py
@@ -272,6 +272,232 @@ def test_card(
     manager.test_card(card_name, cards_dir)
 
 
+@app.command("deploy-app")
+def deploy_app(
+    env_file: Annotated[Path, typer.Option(help="Path to .env file")] = Path(".env"),
+    service: Annotated[str, typer.Option(help="Cloud Run service name")] = (
+        "chatops-chat-app"
+    ),
+    source: Annotated[Path, typer.Option(help="Handler source directory")] = Path(
+        "agent_soc_manager/tools/chatops"
+    ),
+):
+    """Deploy the native Chat App handler to Cloud Run (issue #62).
+
+    Serves /chat/events (interaction events), /tasks/execute (Cloud Tasks
+    worker), and the legacy /action route.
+    """
+    manager = ChatOpsManager(env_file)
+    if not manager.project_id:
+        typer.secho("Error: GCP_PROJECT_ID not set in .env", fg=typer.colors.RED)
+        raise typer.Exit(1)
+
+    env = manager.env_vars
+    project_number = env.get("GCP_PROJECT_NUMBER", "")
+    if not project_number:
+        try:
+            project_number = subprocess.check_output(
+                [
+                    "gcloud",
+                    "projects",
+                    "describe",
+                    manager.project_id,
+                    "--format",
+                    "value(projectNumber)",
+                ],
+                text=True,
+            ).strip()
+        except Exception:
+            typer.secho(
+                "Warning: could not resolve GCP_PROJECT_NUMBER; "
+                "Chat JWT verification will fail until it is set.",
+                fg=typer.colors.YELLOW,
+            )
+
+    run_env = {
+        "CHRONICLE_CHATOPS_SECRET": env.get("CHRONICLE_CHATOPS_SECRET", ""),
+        "GCP_PROJECT_ID": manager.project_id,
+        "GCP_LOCATION": manager.region,
+        "GCP_PROJECT_NUMBER": project_number,
+        "CHATOPS_TASKS_QUEUE": env.get("CHATOPS_TASKS_QUEUE", "chatops-actions"),
+        "CHATOPS_TASKS_LOCATION": env.get("CHATOPS_TASKS_LOCATION", manager.region),
+        "CHATOPS_SERVICE_URL": env.get("CHATOPS_SERVICE_URL", ""),
+        "CHATOPS_INVOKER_SA": env.get("CHATOPS_INVOKER_SA", ""),
+    }
+    env_vars_arg = ",".join(f"{k}={v}" for k, v in run_env.items() if v)
+
+    cmd = [
+        "gcloud",
+        "run",
+        "deploy",
+        service,
+        "--project",
+        manager.project_id,
+        "--region",
+        manager.region,
+        f"--source={source}",
+        "--allow-unauthenticated",
+        f"--set-env-vars={env_vars_arg}",
+    ]
+    typer.echo(f"Deploying {service} to Cloud Run in {manager.region}...")
+    try:
+        subprocess.run(cmd, check=True)
+        typer.secho(f"Successfully deployed {service}.", fg=typer.colors.GREEN)
+        typer.echo(
+            "If this is the first deploy, set CHATOPS_SERVICE_URL in .env to the "
+            "service URL above and redeploy so the worker OIDC audience matches."
+        )
+    except subprocess.CalledProcessError as e:
+        typer.secho(f"Deploy failed: {e}", fg=typer.colors.RED)
+        raise typer.Exit(1)
+
+
+@app.command("create-queue")
+def create_queue(
+    env_file: Annotated[Path, typer.Option(help="Path to .env file")] = Path(".env"),
+):
+    """Create the Cloud Tasks queue that decouples clicks from agent latency."""
+    manager = ChatOpsManager(env_file)
+    if not manager.project_id:
+        typer.secho("Error: GCP_PROJECT_ID not set in .env", fg=typer.colors.RED)
+        raise typer.Exit(1)
+
+    queue = manager.env_vars.get("CHATOPS_TASKS_QUEUE", "chatops-actions")
+    location = manager.env_vars.get("CHATOPS_TASKS_LOCATION", manager.region)
+
+    describe = subprocess.run(
+        [
+            "gcloud",
+            "tasks",
+            "queues",
+            "describe",
+            queue,
+            "--project",
+            manager.project_id,
+            "--location",
+            location,
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if describe.returncode == 0:
+        typer.secho(
+            f"Queue '{queue}' already exists in {location}.", fg=typer.colors.GREEN
+        )
+        return
+
+    typer.echo(f"Creating Cloud Tasks queue '{queue}' in {location}...")
+    try:
+        subprocess.run(
+            [
+                "gcloud",
+                "tasks",
+                "queues",
+                "create",
+                queue,
+                "--project",
+                manager.project_id,
+                "--location",
+                location,
+                "--max-attempts=3",
+                "--max-concurrent-dispatches=10",
+            ],
+            check=True,
+        )
+        typer.secho(f"Queue '{queue}' created.", fg=typer.colors.GREEN)
+    except subprocess.CalledProcessError as e:
+        typer.secho(f"Queue creation failed: {e}", fg=typer.colors.RED)
+        raise typer.Exit(1)
+
+
+@app.command("registration-guide")
+def registration_guide():
+    """Print the manual Google Chat App registration steps (one-time setup)."""
+    typer.secho("Google Chat App Registration (manual, one-time)", bold=True)
+    typer.echo(
+        """
+1. Enable the Google Chat API:
+   gcloud services enable chat.googleapis.com
+
+2. Open the Chat API configuration page:
+   https://console.cloud.google.com/apis/api/chat.googleapis.com/hangouts-chat
+
+3. Under "Application info", set:
+   - App name:        SOC Agent ChatOps
+   - Avatar URL:      any hosted icon
+   - Description:     Background approval actions for SOC agents
+
+4. Under "Interactive features":
+   - Enable "Receive 1:1 messages" and "Join spaces and group conversations"
+   - Connection settings: select "HTTP endpoint URL"
+   - HTTP endpoint URL: <CHATOPS_SERVICE_URL>/chat/events
+     (deploy first with: python manage.py chatops deploy-app)
+
+5. Under "Visibility", make the app available to your domain or
+   specific users, then click Save.
+
+6. In Google Chat, add the app to your SOC space, then set in .env:
+   - CHAT_SPACE=spaces/<space id>      (from the space URL)
+   - CHATOPS_MODE=chat_app
+   - GCP_PROJECT_NUMBER=<project number>
+
+7. Grant the Cloud Run service account permission to enqueue tasks
+   (roles/cloudtasks.enqueuer) and set CHATOPS_INVOKER_SA to a service
+   account with run.invoker on the Cloud Run service.
+
+8. Redeploy the Agent Engine agents so the new CHATOPS_MODE takes effect.
+"""
+    )
+
+
+@app.command("verify-config")
+def verify_config(
+    env_file: Annotated[Path, typer.Option(help="Path to .env file")] = Path(".env"),
+):
+    """Check that the environment is complete for the configured ChatOps mode."""
+    manager = ChatOpsManager(env_file)
+    env = manager.env_vars
+    mode = env.get("CHATOPS_MODE", "webhook").strip().lower()
+    typer.echo(f"CHATOPS_MODE: {mode}")
+
+    if mode == "chat_app":
+        required = [
+            "CHAT_SPACE",
+            "GCP_PROJECT_ID",
+            "GCP_PROJECT_NUMBER",
+            "CHATOPS_SERVICE_URL",
+            "CHRONICLE_CHATOPS_SECRET",
+        ]
+        recommended = [
+            "CHATOPS_TASKS_QUEUE",
+            "CHATOPS_TASKS_LOCATION",
+            "CHATOPS_INVOKER_SA",
+        ]
+    else:
+        required = ["WEBHOOK_URL", "CHATOPS_BASE_URL", "CHRONICLE_CHATOPS_SECRET"]
+        recommended = []
+
+    ok = True
+    for name in required:
+        if env.get(name):
+            typer.secho(f"  [set]     {name}", fg=typer.colors.GREEN)
+        else:
+            typer.secho(f"  [MISSING] {name}", fg=typer.colors.RED)
+            ok = False
+    for name in recommended:
+        if env.get(name):
+            typer.secho(f"  [set]     {name}", fg=typer.colors.GREEN)
+        else:
+            typer.secho(
+                f"  [default] {name} (using built-in default)", fg=typer.colors.YELLOW
+            )
+
+    if not ok:
+        typer.secho("Configuration incomplete for this mode.", fg=typer.colors.RED)
+        raise typer.Exit(1)
+    typer.secho("Configuration looks complete.", fg=typer.colors.GREEN)
+
+
 @app.command("deploy")
 def deploy(
     env_file: Annotated[Path, typer.Option(help="Path to .env file")] = Path(".env"),

--- a/justfile
+++ b/justfile
@@ -1012,6 +1012,34 @@ alias agentspace-datastore := gem-ent-datastore
 alias agentspace-link-agent := gem-ent-link-agent
 alias agentspace-unlink-agent := gem-ent-unlink-agent
 alias agentspace-update-agent := gem-ent-update-agent
+# ============================================================================
+# ChatOps Native Chat App (issue #62)
+# ============================================================================
+
+# List available ChatOps card templates
+chatops-list:
+    {{ python }} manage.py chatops list --env-file {{ env_file }}
+
+# Send a specific ChatOps card to test delivery (webhook or chat_app mode)
+chatops-test card:
+    {{ python }} manage.py chatops test {{ card }} --env-file {{ env_file }}
+
+# Deploy the native Chat App handler (events + worker + legacy action) to Cloud Run
+chatops-deploy-app:
+    {{ python }} manage.py chatops deploy-app --env-file {{ env_file }}
+
+# Create the Cloud Tasks queue that decouples card clicks from agent latency
+chatops-create-queue:
+    {{ python }} manage.py chatops create-queue --env-file {{ env_file }}
+
+# Print the one-time Google Chat App registration steps
+chatops-registration-guide:
+    {{ python }} manage.py chatops registration-guide
+
+# Verify the environment is complete for the configured CHATOPS_MODE
+chatops-verify:
+    {{ python }} manage.py chatops verify-config --env-file {{ env_file }}
+
 alias agentspace-list-agents := gem-ent-list-agents
 alias agentspace-list-apps := gem-ent-list-apps
 alias agentspace-create-app := gem-ent-create-app

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,9 +95,10 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*.py" = ["S101"]  # Allow assert in tests
-"agent_soc_manager/tools/chatops/test_*.py" = ["S101"]
+"agent_soc_manager/tools/chatops/test_*.py" = ["S101", "S105", "E402"]  # test secrets and post-bootstrap imports
 "agent_soc_manager/tools/chatops/generate_test_url.py" = ["S105", "E402"]
 "agent_soc_manager/tools/chatops/webhook_handler.py" = ["S104"]
+"agent_soc_manager/tools/chatops/chat_app_handler.py" = ["S104"]
 "installation_scripts/*.py" = [
   "S603",  # subprocess calls are trusted (gcloud CLI)
   "S607",  # partial executable paths are acceptable (gcloud in PATH)


### PR DESCRIPTION
Implements #62 (Phase 2 Integration).

## What changes

**1. Background execution (zero-tab UX).** With `CHATOPS_MODE=chat_app`, cards post through the Chat REST API as the registered Chat App, and button clicks arrive as `CARD_CLICKED` interaction events instead of opening a browser tab. The migration happens at one seam: `chat_api.convert_openlink_to_action()` rewrites every template's signed `openLink` buttons into native `onClick.action` payloads at dispatch time, so **all 55 card templates migrate with zero template edits**. Informational links (View in Chronicle) stay as links.

**2. Decoupled latency (30s deadline vs minutes-long queries).** `POST /chat/events` (Cloud Run, `chat_app_handler.py`) verifies the Google-issued bearer JWT (issuer `chat@system.gserviceaccount.com`, audience project number), HMAC-verifies the signed action token (existing `security.py`, defense in depth), enqueues a **Cloud Tasks** task, and immediately returns an in-place *Processing* card update. Task names derive from the token hash so analyst double-clicks dedupe to one execution. Cloud Tasks was chosen over Pub/Sub: OIDC-authenticated HTTP push to the same service with built-in retry, no subscriber deployment, and its dispatch deadline comfortably covers minutes-long Agent Engine queries (Pub/Sub push caps at 600s ack).

**3. State synchronization.** `POST /tasks/execute` (OIDC-verified worker) re-verifies the token, runs `async_stream_query` against Agent Engine, then PATCHes the original card with the confirmed outcome — or an honest failure ("No state change was confirmed"). The worker returns 200 even on agent failure by design: a retry would re-execute an approved state-changing action; the failure is surfaced to the human instead.

## Compatibility

- `CHATOPS_MODE` defaults to `webhook` — the legacy path is byte-for-byte untouched until opt-in; rollback is unsetting one env var.
- The legacy `GET /action` route is still served by the new handler so in-flight signed URLs (1h TTL) work during cutover.
- `webhook_handler.py` is retained for rollback; the Dockerfile now targets `chat_app_handler:app`.

## Setup

```bash
just chatops-deploy-app          # Cloud Run handler
just chatops-create-queue        # Cloud Tasks queue
just chatops-registration-guide  # one-time manual Chat App registration steps
just chatops-verify              # validate env for the configured mode
```

Full architecture + IAM summary: `docs/chatops_chat_app.md`. New env vars documented in `.env.example` (`CHAT_SPACE`, `GCP_PROJECT_NUMBER`, `CHATOPS_SERVICE_URL`, `CHATOPS_TASKS_*`, `CHATOPS_INVOKER_SA`).

## Testing

Offline unit suite `agent_soc_manager/tools/chatops/test_chat_app.py` (10 tests, no GCP needed): transform correctness/idempotency, event auth rejection, enqueue-and-ack flow, worker success/failure card sync, invalid-token rejection, legacy route presence, dual-mode dispatch routing. All lint gates (ruff, pyink, compileall) green.

Closes #62