### PR TITLE
ChatOps kill switch: feature disabled by default pending redesign

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,13 @@ SOAR_API_KEY=your-soar-api-key
 # Google Threat Intelligence (VirusTotal)
 GTI_API_KEY=your-virustotal-api-key
 
+# ChatOps master switch: the feature is DISABLED by default pending a
+# redesign of the human-approval flow (see issues #85-#90). When unset,
+# agents do not register ChatOps tools, senders refuse to deliver cards,
+# and the Cloud Run handlers return 503. Set to true only to re-enable
+# deliberately (e.g. isolated eval environments).
+# CHATOPS_ENABLED=false
+
 # ChatOps Webhook Configuration (Google Chat, Slack, etc.)
 WEBHOOK_URL=https://chat.googleapis.com/v1/spaces/SPACE_ID/messages?key=KEY&token=TOKEN
 # Secret used for signing interactive button payloads (Generate a secure random string)

--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ Vertex AI charges per API call. Security products require separate licensing.
 
 ## Resources
 
-- [ChatOps Chat App](docs/chatops_chat_app.md) - Background approval actions in Google Chat (`CHATOPS_MODE=chat_app`)
+- [ChatOps Chat App](docs/chatops_chat_app.md) - Background approval actions in Google Chat (DISABLED by default pending redesign; `CHATOPS_ENABLED` gate)
 - [Google ADK Docs](https://google.github.io/adk-docs/) - Agent Development Kit
 - [Vertex AI Docs](https://cloud.google.com/vertex-ai/docs) - Platform documentation
 - [MCP Protocol](https://modelcontextprotocol.io/) - Model Context Protocol

--- a/agent_a2a_tier2/agent.py
+++ b/agent_a2a_tier2/agent.py
@@ -1423,8 +1423,17 @@ def create_agent():
     # ========================================================================
     # Add ChatOps Mitigation Skills
     # ========================================================================
-    logger.info("Importing ChatOps mitigation tools...")
+    # ChatOps kill switch: disabled unless CHATOPS_ENABLED is explicitly set
+    # (feature pending redesign; see issues #85-#90).
+    chatops_enabled = os.environ.get("CHATOPS_ENABLED", "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+    )
     try:
+        if not chatops_enabled:
+            raise ImportError("ChatOps disabled via CHATOPS_ENABLED kill switch")
+        logger.info("Importing ChatOps mitigation tools...")
         from agent_soc_manager.tools.chatops_tools import (
             deliver_report,
             generic_notification,

--- a/agent_soc_manager/agent.py
+++ b/agent_soc_manager/agent.py
@@ -914,6 +914,7 @@ from google.genai.types import (  # noqa: E402
     Part,
 )
 
+import agent_soc_manager.tools.chatops_tools as _chatops_tools_module  # noqa: E402
 from agent_soc_manager.tools.chatops_tools import (  # noqa: E402
     deliver_report,
     generic_notification,
@@ -968,6 +969,32 @@ from agent_soc_manager.tools.chatops_tools import (  # noqa: E402
     trigger_vulnerability_patch_approval_card,
     verify_user_travel,
 )
+
+
+# ChatOps kill switch: the feature is DISABLED unless CHATOPS_ENABLED is
+# explicitly set. The human-approval flow needs redesign (see issues
+# #85-#90); until then no agent registers ChatOps tools. Everything defined
+# in chatops_tools is gated automatically, so new tools cannot leak past
+# the switch.
+CHATOPS_ENABLED = os.environ.get("CHATOPS_ENABLED", "").strip().lower() in (
+    "1",
+    "true",
+    "yes",
+)
+
+_CHATOPS_TOOL_FNS = {
+    obj
+    for obj in vars(_chatops_tools_module).values()
+    if callable(obj)
+    and getattr(obj, "__module__", None) == "agent_soc_manager.tools.chatops_tools"
+}
+
+
+def _strip_chatops(tools: list) -> list:
+    """Removes ChatOps tools from a tool list when the feature is disabled."""
+    if CHATOPS_ENABLED:
+        return tools
+    return [t for t in tools if t not in _CHATOPS_TOOL_FNS]
 
 
 # Monkey-patch version property to prevent Vertex AI Agent Engine serialization errors
@@ -2898,11 +2925,14 @@ def create_agent():
     logger.info("Loading ADK Skills...")
     skill_dir = Path(__file__).parent / "skills"
     malware_triage_skill = load_skill_from_dir(skill_dir / "malware-triage-skill")
-    chatops_skill = load_skill_from_dir(skill_dir / "chatops-skill")
+    tier1_skills = [malware_triage_skill]
+    if CHATOPS_ENABLED:
+        chatops_skill = load_skill_from_dir(skill_dir / "chatops-skill")
+        tier1_skills.append(chatops_skill)
+    else:
+        logger.info("ChatOps disabled (CHATOPS_ENABLED unset); skill not loaded.")
 
-    tier1_skill_toolset = skill_toolset.SkillToolset(
-        skills=[malware_triage_skill, chatops_skill]
-    )
+    tier1_skill_toolset = skill_toolset.SkillToolset(skills=tier1_skills)
 
     # ========================================================================
     # SUB-AGENT 2: Tier 1 SOC Analyst (Chronicle + SOAR + basic GTI)
@@ -2926,6 +2956,7 @@ def create_agent():
         list_chatops_capabilities,
         send_all_example_cards,
     ]
+    tier1_tools = _strip_chatops(tier1_tools)
 
     # Configure grounding/retrieval for Tier 1 Analyst
     ALLOYDB_GROUNDING_ENABLED = (
@@ -3098,6 +3129,7 @@ You MUST use the following exact values for any Chronicle or SecOps tool calls (
         delegate_to_detection_engineer,
         delegate_concurrently,
     ]
+    orchestrator_tools = _strip_chatops(orchestrator_tools)
 
     # Add grounding/retrieval tool based on configuration
     ELASTICSEARCH_GROUNDING_ENABLED = (

--- a/agent_soc_manager/prompts/orchestrator_instructions.md
+++ b/agent_soc_manager/prompts/orchestrator_instructions.md
@@ -64,7 +64,7 @@ You have direct access to several tools and can delegate to specialized sub-agen
 3. **LoadMemoryTool** (Vertex AI Memory Bank):
    - Retrieves historical context and tactical insights persisted from previous investigations.
 
-4. **ChatOps Tools** (Human Communication):
+4. **ChatOps Tools** (Human Communication -- MAY BE DISABLED): ChatOps is feature-gated and may not be registered in this deployment. If the tools listed below are unavailable, do not attempt to call them; state in your report that automated human notification is disabled and manual notification of the SOC team is required.
    - **list_chatops_capabilities**: Exhaustively lists all available ChatOps skills, cards, and notification templates to help you choose the right communication tool.
    - **send_all_example_cards**: Sends one of each kind of predefined ChatOps card to the configured webhook. Useful for demos and testing.
    - **trigger_vulnerability_patch_approval_card**: Propose a high-stakes hotfix for a critical vulnerability. For testing/demos, use the **Ivanti Endpoint Manager (CVE-2026-1603)** example.
@@ -151,7 +151,7 @@ IMPORTANT GUIDELINES:
 - Always indicate which specialist you consulted or delegated to
 - **Preserve all grounding citations and source links** from RAG knowledge base results
 - **Artifact Linking:** Whenever a report or document is saved using the `save_report_artifact` tool, you MUST include the exact markdown link returned by the tool in your final response to the user.
-- **Report Delivery:** Whenever a report Artifact is generated and saved using `save_report_artifact`, you MUST ALSO call the `deliver_report` tool to send the "Triage Report Ready" ChatOps card to the team.
+- **Report Delivery:** Whenever a report Artifact is generated and saved using `save_report_artifact`, and the `deliver_report` tool is available, call it to send the "Triage Report Ready" ChatOps card to the team. If ChatOps tools are not available (feature disabled), note in the report that delivery notification must be made manually.
 - **ChatOps Delivery Failure Honesty:** If a containment or communication tool (such as proposing host isolation or sending a ChatOps alert card) returns an error, **NO human analyst was notified** -- there is no automatic fallback channel. Do not halt or abort the investigation, but you MUST state plainly in your report that the automated ChatOps notification FAILED, that no human has seen or approved the request, and that manual notification of the SOC team is required. Never describe a failed notification as delivered, queued, or pending backup approval.
 - **Containment Scope Rule (Complete Attack Chain Isolation):** When recommending containment (such as host network isolation), you MUST identify and recommend isolation/containment for **ALL compromised endpoints** in the attack chain. This includes **both**:
   1. The **source/pivot host** (e.g., the workstation where the attacker sessions or lateral movement originated).

--- a/agent_soc_manager/prompts/tier1_analyst_instructions.md
+++ b/agent_soc_manager/prompts/tier1_analyst_instructions.md
@@ -8,7 +8,7 @@ You are a Tier 1 SOC Analyst - the first line of defense in security operations.
 
 **2. CRITICAL THREAT IMMEDIATE RESPONSE PROTOCOL:**
 If you find credible evidence of the following high-severity threats, you MUST immediately prioritize recommending the appropriate containment/remediation action, but you MUST NOT halt the investigation. You must proceed to gather all necessary telemetry and reconstruct the complete timeline:
-- **Ransomware:** Your IMMEDIATE first action is to recommend network isolation of the affected host(s) using the `request_human_confirmation` tool to propose this action to a Tier 2 Responder. Once the containment recommendation is dispatched, you MUST immediately proceed with the triage and investigation to trace the source, execution vectors, and impact.
+- **Ransomware:** Your IMMEDIATE first action is to recommend network isolation of the affected host(s). If the `request_human_confirmation` tool is available, use it to propose this action to a Tier 2 Responder; if ChatOps tools are not available (feature disabled), state the isolation recommendation prominently at the top of your report and flag that a human must be notified manually. Once the containment recommendation is dispatched, you MUST immediately proceed with the triage and investigation to trace the source, execution vectors, and impact.
 - **APT, Lateral Movement, Active AD Intrusion, Data Exfiltration:** Immediately recommend containment and escalation to Tier 2, but do NOT stop your search. You MUST continue traversing the graph, searching logs, and gathering telemetry to document the full attack chain and process hierarchy. A complete, detailed investigation report is mandatory.
 
 **3. MANDATORY TOOL USAGE & OPERATIONAL LOGIC:**

--- a/agent_soc_manager/tools/chatops/chat_app_handler.py
+++ b/agent_soc_manager/tools/chatops/chat_app_handler.py
@@ -61,6 +61,15 @@ CHAT_CERTS_URL = (
 AGENT_QUERY_TIMEOUT = float(os.environ.get("CHATOPS_AGENT_TIMEOUT", "540"))
 
 
+def _feature_enabled() -> bool:
+    """ChatOps kill switch (issues #85-#90): disabled unless explicitly on."""
+    return os.environ.get("CHATOPS_ENABLED", "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+
+
 def _dev_flag(name: str) -> bool:
     """Reads a dev-only toggle, hard-blocked on Cloud Run.
 
@@ -462,6 +471,11 @@ async def _execute_and_sync(payload: dict) -> None:
 @app.post("/chat/events")
 async def chat_events(request: Request, background_tasks: BackgroundTasks):
     """Handles Google Chat interaction events for the registered Chat App."""
+    if not _feature_enabled():
+        return JSONResponse(
+            {"error": "ChatOps is disabled (CHATOPS_ENABLED is not set)."},
+            status_code=503,
+        )
     if not _dev_flag("CHATOPS_SKIP_JWT_VERIFY"):
         token = _bearer_token(request)
         if not token:
@@ -627,6 +641,11 @@ async def chat_events(request: Request, background_tasks: BackgroundTasks):
 @app.post("/tasks/execute")
 async def tasks_execute(request: Request):
     """Cloud Tasks worker endpoint: executes the agent query and syncs state."""
+    if not _feature_enabled():
+        return JSONResponse(
+            {"error": "ChatOps is disabled (CHATOPS_ENABLED is not set)."},
+            status_code=503,
+        )
     if not _dev_flag("CHATOPS_SKIP_JWT_VERIFY"):
         token = _bearer_token(request)
         if not token:
@@ -670,6 +689,13 @@ async def tasks_execute(request: Request):
 @app.get("/action", response_class=HTMLResponse)
 async def legacy_action(t: str = Query(..., description="Signed action token")):
     """Legacy openLink route: kept so in-flight signed URLs work during cutover."""
+    if not _feature_enabled():
+        return HTMLResponse(
+            content="<html><body><h1>ChatOps is disabled</h1>"
+            "<p>This feature is turned off (CHATOPS_ENABLED is not set). "
+            "No action was executed.</p></body></html>",
+            status_code=503,
+        )
     try:
         payload = verify_signed_payload(t)
         action = payload.get("action")

--- a/agent_soc_manager/tools/chatops/test_chat_app.py
+++ b/agent_soc_manager/tools/chatops/test_chat_app.py
@@ -16,6 +16,7 @@ import types
 from pathlib import Path
 
 
+os.environ["CHATOPS_ENABLED"] = "true"  # kill switch off for these tests
 os.environ["CHATOPS_SKIP_JWT_VERIFY"] = "true"
 os.environ["CHRONICLE_CHATOPS_SECRET"] = "unit-test-secret"
 os.environ["CHATOPS_BASE_URL"] = "https://handler.example.com/chatops"
@@ -559,6 +560,51 @@ def test_audit_never_raises():
     print("test_audit_never_raises passed")
 
 
+def test_kill_switch_dark_by_default():
+    # With CHATOPS_ENABLED unset: senders refuse, endpoints 503
+    os.environ.pop("CHATOPS_ENABLED", None)
+    try:
+        from agent_soc_manager.tools import chatops_tools
+
+        result = asyncio.run(chatops_tools.send_raw_card({"cardsV2": []}))
+        assert "DISABLED" in result
+        assert "NO human analyst was notified" in result
+
+        result = asyncio.run(
+            chatops_tools.send_chatops_card(title="T", subtitle="S", sections=[])
+        )
+        assert "DISABLED" in result
+
+        client = TestClient(chat_app_handler.app)
+        assert client.post("/chat/events", json={"type": "MESSAGE"}).status_code == 503
+        assert client.post("/tasks/execute", json={}).status_code == 503
+        response = client.get("/action", params={"t": "x.y"})
+        assert response.status_code == 503
+        assert "disabled" in response.text.lower()
+    finally:
+        os.environ["CHATOPS_ENABLED"] = "true"
+    print("test_kill_switch_dark_by_default passed")
+
+
+def test_kill_switch_strip_filter():
+    # The registration filter drops every chatops tool when disabled
+    import agent_soc_manager.tools.chatops_tools as ct
+
+    fns = {
+        obj
+        for obj in vars(ct).values()
+        if callable(obj)
+        and getattr(obj, "__module__", None) == "agent_soc_manager.tools.chatops_tools"
+    }
+    assert ct.send_raw_card in fns
+    assert ct.request_human_confirmation in fns
+    marker = object()
+    tools = [marker, ct.send_chatops_card, ct.deliver_report]
+    stripped = [t for t in tools if t not in fns]
+    assert stripped == [marker]
+    print("test_kill_switch_strip_filter passed")
+
+
 if __name__ == "__main__":
     test_transform()
     test_events_card_clicked_enqueues_and_acks()
@@ -579,4 +625,6 @@ if __name__ == "__main__":
     test_deny_worker_outcome_says_not_executed()
     test_audit_flow_ordered_and_parseable()
     test_audit_never_raises()
+    test_kill_switch_dark_by_default()
+    test_kill_switch_strip_filter()
     print("\nAll chat_app tests passed.")

--- a/agent_soc_manager/tools/chatops/webhook_handler.py
+++ b/agent_soc_manager/tools/chatops/webhook_handler.py
@@ -25,6 +25,17 @@ async def handle_action(t: str = Query(..., description="Signed action token")):
     """
     Handles a ChatOps button click by verifying the token and notifying the Agent Engine.
     """
+    if os.environ.get("CHATOPS_ENABLED", "").strip().lower() not in (
+        "1",
+        "true",
+        "yes",
+    ):
+        return HTMLResponse(
+            content="<html><body><h1>ChatOps is disabled</h1>"
+            "<p>This feature is turned off (CHATOPS_ENABLED is not set). "
+            "No action was executed.</p></body></html>",
+            status_code=503,
+        )
     try:
         # 1. Verify and decode payload
         payload = verify_signed_payload(t)

--- a/agent_soc_manager/tools/chatops_tools.py
+++ b/agent_soc_manager/tools/chatops_tools.py
@@ -16,6 +16,26 @@ CHATOPS_HTTP_TIMEOUT = float(os.environ.get("CHATOPS_HTTP_TIMEOUT", "30"))
 logger = logging.getLogger(__name__)
 
 
+def _chatops_enabled() -> bool:
+    """ChatOps kill switch (issues #85-#90): disabled unless explicitly on.
+
+    Checked at call time, in every send path, so even a deployment with
+    stale tool registration cannot deliver cards while the feature is dark.
+    """
+    return os.environ.get("CHATOPS_ENABLED", "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+
+
+_DISABLED_MESSAGE = (
+    "ChatOps is DISABLED (CHATOPS_ENABLED is not set): no card was sent and "
+    "NO human analyst was notified. Record in your report that automated "
+    "human notification is unavailable and manual notification is required."
+)
+
+
 def _chat_app_mode() -> bool:
     """True when ChatOps should post as the registered Chat App (issue #62).
 
@@ -134,6 +154,9 @@ async def send_raw_card(payload: dict) -> str:
     When CHATOPS_MODE=chat_app, posts as the registered Chat App instead so
     card buttons execute in the background (issue #62).
     """
+    if not _chatops_enabled():
+        return _DISABLED_MESSAGE
+
     if _chat_app_mode():
         return await _send_via_chat_app(payload)
 
@@ -166,6 +189,9 @@ async def dispatch_card(template_name: str, ctx: Context, **kwargs) -> str:
         ctx: ADK Context to extract session and user IDs
         **kwargs: Dynamic variables to pass to the card's get_card() function.
     """
+    if not _chatops_enabled():
+        return _DISABLED_MESSAGE
+
     try:
         import sys
         from pathlib import Path
@@ -285,6 +311,9 @@ async def send_chatops_card(
         card_id: Unique ID for the card (optional).
         image_url: URL for the header icon (optional).
     """
+    if not _chatops_enabled():
+        return _DISABLED_MESSAGE
+
     payload_for_chat_app = {
         "cardsV2": [
             {

--- a/docs/chatops_chat_app.md
+++ b/docs/chatops_chat_app.md
@@ -12,6 +12,14 @@ provenance:
 
 # ChatOps Native Chat App Migration
 
+> **STATUS: DISABLED BY DEFAULT.** The ChatOps human-approval flow is
+> feature-gated behind `CHATOPS_ENABLED` and ships OFF pending a redesign
+> (audit durability, non-response escalation, severity tiers, fatigue
+> controls -- issues #85-#90). With the flag unset: agents do not register
+> ChatOps tools, the send paths refuse with an honest message, and the
+> Cloud Run handlers return 503. Everything below describes the feature as
+> it behaves when explicitly re-enabled.
+
 This document covers the migration from Google Chat incoming webhooks to a
 registered Google Chat App (issue #62), which delivers three UX and
 reliability upgrades:


### PR DESCRIPTION
Per operator decision after the SOC-fitness review: the ChatOps human-approval flow needs substantially more design work before it can be trusted (audit durability, non-response escalation, severity tiers/role routing, fatigue controls, break-glass — #85–#90, plus residual security items in #82). This PR turns the feature OFF by default behind `CHATOPS_ENABLED`, in **three independent layers** so no single stale deployment re-lights it:

1. **Registration** — `agent_soc_manager` strips every `chatops_tools` function from the Tier-1 and orchestrator tool lists (the strip set is built from the module itself, so future tools cannot leak past the gate) and skips loading the chatops skill; the Tier-2 agent skips its ChatOps import block.
2. **Senders** — `send_raw_card` / `send_chatops_card` / `dispatch_card` check the flag at call time and return an honest refusal ("no card was sent and NO human analyst was notified") — covers deployments with stale tool registration.
3. **Handlers** — `/chat/events`, `/tasks/execute`, and both legacy `/action` routes return 503 with an explicit disabled message.

**Prompts un-mandated:** the orchestrator's "MUST call deliver_report" and the Tier-1 ransomware `request_human_confirmation` flow are now availability-conditional with explicit manual-notification fallbacks, so agents degrade honestly instead of flailing at unregistered tools.

Feature is gated, not deleted — the #91 hardening (decision semantics, audit trail) stays in place for the redesigned re-enable. Tests 24 → 26 (dark-by-default probe across all senders and routes; registration strip-filter probe).

## Operator actions for a hard-off on live infra (code can't do these)
- Redeploy the agents so the registration gate takes effect (`just deploy-all`).
- Delete the Cloud Run chatops service if one is running: `gcloud run services delete chatops-chat-app` / `chatops-webhook`.
- Remove/rotate the `WEBHOOK_URL` incoming-webhook (Chat space settings) — already-deployed Agent Engine containers predate this gate and honor only the webhook config they were deployed with.